### PR TITLE
feat: adding staking allow spends validation, and generating the spend transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
+.bsp/
 target/
 project/project/

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,10 @@
+rules = [
+    OrganizeImports
+]
+
+OrganizeImports {
+  groupedImports                    = Merge
+  coalesceToWildcardImportThreshold = 3
+  groups                            = ["re:javax?\\.", "cats.", "scala.", "io.constellationnetwork.", "*"]
+  removeUnused                      = true
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,32 @@
+version=3.5.8
+runner.dialect = scala213
+
+preset = default
+align.preset = some
+
+newlines.topLevelStatementBlankLines = [
+  { blanks = 0 }
+]
+newlines.penalizeSingleSelectMultiArgList = false
+newlines.avoidAfterYield = false
+newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
+newlines.implicitParamListModifierPrefer = before
+
+danglingParentheses.preset = true
+
+includeCurlyBraceInSelectChains = false
+
+maxColumn = 140
+indent.defnSite = 2
+indent.callSite = 2
+
+project.git = true
+
+rewrite.rules = [
+  AvoidInfix
+  RedundantBraces
+  RedundantParens
+  AsciiSortImports
+  PreferCurlyFors
+]
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,13 @@
 import Dependencies.*
 import sbt.*
 
-ThisBuild / organization := "org.constellation"
+ThisBuild / organization := "io.constellationnetwork"
 ThisBuild / organizationName := "amm_metagraph"
 ThisBuild / scalaVersion := "2.13.14"
+
 ThisBuild / evictionErrorLevel := Level.Warn
+ThisBuild / scalafixDependencies += Libraries.organizeImports
+
 
 ThisBuild / assemblyMergeStrategy := {
   case "logback.xml" => MergeStrategy.first
@@ -17,6 +20,8 @@ ThisBuild / assemblyMergeStrategy := {
 
 lazy val commonTestSettings = Seq(
   testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
+  scalafmtOnCompile := true,
+  scalafixOnCompile := true,
   libraryDependencies ++= Seq(
     Libraries.weaverCats,
     Libraries.weaverDiscipline,

--- a/modules/data_l1/src/main/scala/org/amm_metagraph/data_l1/Main.scala
+++ b/modules/data_l1/src/main/scala/org/amm_metagraph/data_l1/Main.scala
@@ -1,32 +1,35 @@
 package org.amm_metagraph.data_l1
 
-import cats.syntax.all._
+import java.util.UUID
+
 import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
 import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
 import org.amm_metagraph.shared_data.types.codecs.JsonBinaryCodec
 import org.amm_metagraph.shared_data.validations.ValidationService
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.l1.CurrencyL1App
-import org.tessellation.ext.cats.effect.ResourceIO
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
-import org.tessellation.security.SecurityProvider
 
-
-import java.util.UUID
-
-object Main extends CurrencyL1App(
-  "currency-data_l1",
-  "currency data L1 node",
-  ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-  tessellationVersion = TessellationVersion.unsafeFrom(org.tessellation.BuildInfo.version),
-  metagraphVersion = MetagraphVersion.unsafeFrom(org.amm_metagraph.data_l1.BuildInfo.version)
-) {
+object Main
+    extends CurrencyL1App(
+      "currency-data_l1",
+      "currency data L1 node",
+      ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
+      tessellationVersion = TessellationVersion.unsafeFrom(io.constellationnetwork.BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(org.amm_metagraph.data_l1.BuildInfo.version)
+    ) {
 
   override def dataApplication: Option[Resource[IO, BaseDataApplicationL1Service[IO]]] = (for {
     implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
     implicit0(json2bin: JsonSerializer[IO]) <- JsonBinaryCodec.forSync[IO].asResource
+    implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
     calculatedStateService <- CalculatedStateService.make[IO].asResource
     validationService <- ValidationService.make[IO].asResource
     l1Service <- DataL1Service.make[IO](calculatedStateService, validationService).asResource

--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/Main.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/Main.scala
@@ -1,32 +1,37 @@
 package org.amm_metagraph.l0
 
+import java.util.UUID
+
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.l0.CurrencyL0App
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
 import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
 import org.amm_metagraph.shared_data.combiners.CombinerService
 import org.amm_metagraph.shared_data.types.codecs.JsonBinaryCodec
 import org.amm_metagraph.shared_data.validations.ValidationService
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.l0.CurrencyL0App
-import org.tessellation.ext.cats.effect.ResourceIO
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
-import org.tessellation.security.SecurityProvider
 
-import java.util.UUID
-
-object Main extends CurrencyL0App(
-  "currency-l0",
-  "currency L0 node",
-  ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-  tessellationVersion = TessellationVersion.unsafeFrom(org.tessellation.BuildInfo.version),
-  metagraphVersion = MetagraphVersion.unsafeFrom(org.amm_metagraph.l0.BuildInfo.version)
-) {
+object Main
+    extends CurrencyL0App(
+      "currency-l0",
+      "currency L0 node",
+      ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
+      tessellationVersion = TessellationVersion.unsafeFrom(io.constellationnetwork.BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(org.amm_metagraph.l0.BuildInfo.version)
+    ) {
 
   override def dataApplication: Option[Resource[IO, BaseDataApplicationL0Service[IO]]] = (for {
     implicit0(sp: SecurityProvider[IO]) <- SecurityProvider.forAsync[IO]
     implicit0(json2bin: JsonSerializer[IO]) <- JsonBinaryCodec.forSync[IO].asResource
+    implicit0(hasher: Hasher[IO]) = Hasher.forJson[IO]
+
     calculatedStateService <- CalculatedStateService.make[IO].asResource
     validationService <- ValidationService.make[IO].asResource
     combinerService <- CombinerService.make[IO].asResource
@@ -34,4 +39,3 @@ object Main extends CurrencyL0App(
   } yield l1Service).some
 
 }
-

--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/MetagraphL0Service.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/MetagraphL0Service.scala
@@ -3,6 +3,14 @@ package org.amm_metagraph.l0
 import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.dataApplication.dataApplication.{DataApplicationBlock, DataApplicationValidationErrorOr}
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+
 import io.circe.{Decoder, Encoder}
 import org.amm_metagraph.l0.custom_routes.CustomRoutes
 import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
@@ -13,19 +21,13 @@ import org.amm_metagraph.shared_data.types.codecs.DataUpdateCodec._
 import org.amm_metagraph.shared_data.validations.ValidationService
 import org.http4s.circe.CirceEntityCodec.circeEntityDecoder
 import org.http4s.{EntityDecoder, HttpRoutes}
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.dataApplication.dataApplication.{DataApplicationBlock, DataApplicationValidationErrorOr}
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.hash.Hash
-import org.tessellation.security.signature.Signed
 
 object MetagraphL0Service {
 
-  def make[F[+_] : Async : JsonSerializer](
+  def make[F[+_]: Async: JsonSerializer](
     calculatedStateService: CalculatedStateService[F],
-    validationService     : ValidationService[F],
-    combinerService       : CombinerService[F]
+    validationService: ValidationService[F],
+    combinerService: CombinerService[F]
   ): F[BaseDataApplicationL0Service[F]] = Async[F].delay {
     makeBaseDataApplicationL0Service(
       calculatedStateService,
@@ -34,103 +36,102 @@ object MetagraphL0Service {
     )
   }
 
-  private def makeBaseDataApplicationL0Service[F[+_] : Async : JsonSerializer](
+  private def makeBaseDataApplicationL0Service[F[+_]: Async: JsonSerializer](
     calculatedStateService: CalculatedStateService[F],
-    validationService     : ValidationService[F],
-    combinerService       : CombinerService[F]
+    validationService: ValidationService[F],
+    combinerService: CombinerService[F]
   ): BaseDataApplicationL0Service[F] =
-    BaseDataApplicationL0Service(
-      new DataApplicationL0Service[F, AmmUpdate, AmmOnChainState, AmmCalculatedState] {
-        override def genesis: DataState[AmmOnChainState, AmmCalculatedState] =
-          DataState(AmmOnChainState(List.empty), AmmCalculatedState(Map.empty))
+    BaseDataApplicationL0Service(new DataApplicationL0Service[F, AmmUpdate, AmmOnChainState, AmmCalculatedState] {
+      override def genesis: DataState[AmmOnChainState, AmmCalculatedState] =
+        DataState(AmmOnChainState(List.empty), AmmCalculatedState(Map.empty))
 
-        override def validateUpdate(
-          update: AmmUpdate
-        )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-          validationService.validateUpdate(update)
+      override def validateUpdate(
+        update: AmmUpdate
+      )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
+        validationService.validateUpdate(update)
 
-        override def validateData(
-          state  : DataState[AmmOnChainState, AmmCalculatedState],
-          updates: NonEmptyList[Signed[AmmUpdate]]
-        )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-          validationService.validateData(updates, state)
+      override def validateData(
+        state: DataState[AmmOnChainState, AmmCalculatedState],
+        updates: NonEmptyList[Signed[AmmUpdate]]
+      )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
+        validationService.validateData(updates, state)
 
-        override def combine(
-          state  : DataState[AmmOnChainState, AmmCalculatedState],
-          updates: List[Signed[AmmUpdate]]
-        )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] =
-          combinerService.combine(state, updates, context.some)
+      override def combine(
+        state: DataState[AmmOnChainState, AmmCalculatedState],
+        updates: List[Signed[AmmUpdate]]
+      )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] =
+        combinerService.combine(state, updates)
 
-        override def dataEncoder: Encoder[AmmUpdate] =
-          implicitly[Encoder[AmmUpdate]]
+      override def dataEncoder: Encoder[AmmUpdate] =
+        implicitly[Encoder[AmmUpdate]]
 
-        override def calculatedStateEncoder: Encoder[AmmCalculatedState] =
-          implicitly[Encoder[AmmCalculatedState]]
+      override def calculatedStateEncoder: Encoder[AmmCalculatedState] =
+        implicitly[Encoder[AmmCalculatedState]]
 
-        override def dataDecoder: Decoder[AmmUpdate] =
-          implicitly[Decoder[AmmUpdate]]
+      override def dataDecoder: Decoder[AmmUpdate] =
+        implicitly[Decoder[AmmUpdate]]
 
-        override def calculatedStateDecoder: Decoder[AmmCalculatedState] =
-          implicitly[Decoder[AmmCalculatedState]]
+      override def calculatedStateDecoder: Decoder[AmmCalculatedState] =
+        implicitly[Decoder[AmmCalculatedState]]
 
-        override def signedDataEntityDecoder: EntityDecoder[F, Signed[AmmUpdate]] =
-          circeEntityDecoder
+      override def signedDataEntityDecoder: EntityDecoder[F, Signed[AmmUpdate]] =
+        circeEntityDecoder
 
-        override def serializeBlock(
-          block: Signed[DataApplicationBlock]
-        ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[Signed[DataApplicationBlock]](block)
+      override def serializeBlock(
+        block: Signed[DataApplicationBlock]
+      ): F[Array[Byte]] =
+        JsonSerializer[F].serialize[Signed[DataApplicationBlock]](block)
 
-        override def deserializeBlock(
-          bytes: Array[Byte]
-        ): F[Either[Throwable, Signed[DataApplicationBlock]]] =
-          JsonSerializer[F].deserialize[Signed[DataApplicationBlock]](bytes)
+      override def deserializeBlock(
+        bytes: Array[Byte]
+      ): F[Either[Throwable, Signed[DataApplicationBlock]]] =
+        JsonSerializer[F].deserialize[Signed[DataApplicationBlock]](bytes)
 
-        override def serializeState(
-          state: AmmOnChainState
-        ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[AmmOnChainState](state)
+      override def serializeState(
+        state: AmmOnChainState
+      ): F[Array[Byte]] =
+        JsonSerializer[F].serialize[AmmOnChainState](state)
 
-        override def deserializeState(
-          bytes: Array[Byte]
-        ): F[Either[Throwable, AmmOnChainState]] =
-          JsonSerializer[F].deserialize[AmmOnChainState](bytes)
+      override def deserializeState(
+        bytes: Array[Byte]
+      ): F[Either[Throwable, AmmOnChainState]] =
+        JsonSerializer[F].deserialize[AmmOnChainState](bytes)
 
-        override def serializeUpdate(
-          update: AmmUpdate
-        ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[AmmUpdate](update)
+      override def serializeUpdate(
+        update: AmmUpdate
+      ): F[Array[Byte]] =
+        JsonSerializer[F].serialize[AmmUpdate](update)
 
-        override def deserializeUpdate(
-          bytes: Array[Byte]
-        ): F[Either[Throwable, AmmUpdate]] =
-          JsonSerializer[F].deserialize[AmmUpdate](bytes)
+      override def deserializeUpdate(
+        bytes: Array[Byte]
+      ): F[Either[Throwable, AmmUpdate]] =
+        JsonSerializer[F].deserialize[AmmUpdate](bytes)
 
-        override def getCalculatedState(implicit context: L0NodeContext[F]): F[(SnapshotOrdinal, AmmCalculatedState)] =
-          calculatedStateService.get.map(calculatedState => (calculatedState.ordinal, calculatedState.state))
+      override def getCalculatedState(implicit context: L0NodeContext[F]): F[(SnapshotOrdinal, AmmCalculatedState)] =
+        calculatedStateService.get.map(calculatedState => (calculatedState.ordinal, calculatedState.state))
 
-        override def setCalculatedState(
-          ordinal: SnapshotOrdinal,
-          state  : AmmCalculatedState
-        )(implicit context: L0NodeContext[F]): F[Boolean] =
-          calculatedStateService.update(ordinal, state)
+      override def setCalculatedState(
+        ordinal: SnapshotOrdinal,
+        state: AmmCalculatedState
+      )(implicit context: L0NodeContext[F]): F[Boolean] =
+        calculatedStateService.update(ordinal, state)
 
-        override def hashCalculatedState(
-          state: AmmCalculatedState
-        )(implicit context: L0NodeContext[F]): F[Hash] =
-          calculatedStateService.hash(state)
+      override def hashCalculatedState(
+        state: AmmCalculatedState
+      )(implicit context: L0NodeContext[F]): F[Hash] =
+        calculatedStateService.hash(state)
 
-        override def routes(implicit context: L0NodeContext[F]): HttpRoutes[F] =
-          CustomRoutes[F](calculatedStateService).public
+      override def routes(implicit context: L0NodeContext[F]): HttpRoutes[F] =
+        CustomRoutes[F](calculatedStateService).public
 
-        override def serializeCalculatedState(
-          state: AmmCalculatedState
-        ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[AmmCalculatedState](state)
+      override def serializeCalculatedState(
+        state: AmmCalculatedState
+      ): F[Array[Byte]] =
+        JsonSerializer[F].serialize[AmmCalculatedState](state)
 
-        override def deserializeCalculatedState(
-          bytes: Array[Byte]
-        ): F[Either[Throwable, AmmCalculatedState]] =
-          JsonSerializer[F].deserialize[AmmCalculatedState](bytes)
-      })
+      override def deserializeCalculatedState(
+        bytes: Array[Byte]
+      ): F[Either[Throwable, AmmCalculatedState]] =
+        JsonSerializer[F].deserialize[AmmCalculatedState](bytes)
+    })
 }

--- a/modules/l1/src/main/scala/org/amm_metagraph/l1/Main.scala
+++ b/modules/l1/src/main/scala/org/amm_metagraph/l1/Main.scala
@@ -1,15 +1,16 @@
 package org.amm_metagraph.l1
 
-import org.tessellation.currency.l1.CurrencyL1App
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
-
 import java.util.UUID
 
-object Main extends CurrencyL1App(
-  "currency-l1",
-  "currency L1 node",
-  ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-  tessellationVersion = TessellationVersion.unsafeFrom(org.tessellation.BuildInfo.version),
-  metagraphVersion = MetagraphVersion.unsafeFrom(org.amm_metagraph.l1.BuildInfo.version)
-) {}
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+
+object Main
+    extends CurrencyL1App(
+      "currency-l1",
+      "currency L1 node",
+      ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
+      tessellationVersion = TessellationVersion.unsafeFrom(io.constellationnetwork.BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(org.amm_metagraph.l1.BuildInfo.version)
+    ) {}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/Utils.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/Utils.scala
@@ -3,24 +3,62 @@ package org.amm_metagraph.shared_data
 import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
-import eu.timepit.refined.types.numeric.PosLong
-import org.tessellation.schema.address.Address
-import org.tessellation.security.SecurityProvider
-import org.tessellation.security.signature.signature.SignatureProof
 
 import scala.collection.SortedSet
 
+import io.constellationnetwork.currency.dataApplication.L0NodeContext
+import io.constellationnetwork.schema.GlobalSnapshotInfo
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.{AllowSpend, CurrencyId}
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.signature.SignatureProof
+import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
+
+import eu.timepit.refined.types.numeric.PosLong
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object Utils {
-  def toAddress[F[_] : Async : SecurityProvider](proof: SignatureProof): F[Address] =
+  def logger[F[_]: Async]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Utils")
+
+  def toAddress[F[_]: Async: SecurityProvider](proof: SignatureProof): F[Address] =
     proof.id.toAddress
 
-  def buildLiquidityPoolUniqueIdentifier[F[_] : MonadThrow](maybeTokenAId: Option[Address], maybeTokenBId: Option[Address]): F[String] =
-    SortedSet(maybeTokenAId, maybeTokenBId)
-      .flatten
+  def buildLiquidityPoolUniqueIdentifier[F[_]: MonadThrow](
+    maybeTokenAId: Option[CurrencyId],
+    maybeTokenBId: Option[CurrencyId]
+  ): F[String] =
+    SortedSet(maybeTokenAId, maybeTokenBId).flatten
       .mkString("-")
       .pure[F]
       .ensure(new IllegalArgumentException("You should provide at least one currency token identifier"))(_.nonEmpty)
+
+  def getLastSyncGlobalSnapshotState[F[_]: Async](implicit context: L0NodeContext[F]): F[GlobalSnapshotInfo] =
+    context.getLastSynchronizedGlobalSnapshotCombined.flatMap {
+      case Some(value) =>
+        val (_, snapshotInfo) = value
+        snapshotInfo.pure
+      case None =>
+        val message = "Could not get last sync global snapshot state"
+        logger.error(message) >> new Exception(message).raiseError[F, GlobalSnapshotInfo]
+    }
+
+  def getAllowSpendsLastSyncGlobalSnapshotState[F[_]: Async: Hasher](
+    tokenAAllowSpend: Hash,
+    tokenBAllowSpend: Hash
+  )(implicit context: L0NodeContext[F]): F[(Option[Hashed[AllowSpend]], Option[Hashed[AllowSpend]])] = for {
+    globalSnapshotInfo <- getLastSyncGlobalSnapshotState
+    currencyId <- context.getMetagraphId
+    response <- globalSnapshotInfo
+      .activeAllowSpends(currencyId)
+      .values
+      .flatten
+      .toList
+      .traverse(_.toHashed)
+      .map { hashedAllowSpends =>
+        (hashedAllowSpends.find(_.hash === tokenAAllowSpend), hashedAllowSpends.find(_.hash === tokenBAllowSpend))
+      }
+  } yield response
 
   implicit class PosLongOps(value: Long) {
     def toPosLongUnsafe: PosLong =

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
@@ -1,7 +1,8 @@
 package org.amm_metagraph.shared_data.calculated_state
 
+import io.constellationnetwork.schema.SnapshotOrdinal
+
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
-import org.tessellation.schema.SnapshotOrdinal
 
 case class CalculatedState(ordinal: SnapshotOrdinal, state: AmmCalculatedState)
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
@@ -1,21 +1,23 @@
 package org.amm_metagraph.shared_data.calculated_state
 
+import java.nio.charset.StandardCharsets
+
 import cats.effect.Ref
 import cats.effect.kernel.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+
 import io.circe.syntax.EncoderOps
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.hash.Hash
-
-import java.nio.charset.StandardCharsets
 
 trait CalculatedStateService[F[_]] {
   def get: F[CalculatedState]
 
   def update(
     snapshotOrdinal: SnapshotOrdinal,
-    state          : AmmCalculatedState
+    state: AmmCalculatedState
   ): F[Boolean]
 
   def hash(
@@ -24,14 +26,14 @@ trait CalculatedStateService[F[_]] {
 }
 
 object CalculatedStateService {
-  def make[F[_] : Async]: F[CalculatedStateService[F]] = {
+  def make[F[_]: Async]: F[CalculatedStateService[F]] =
     Ref.of[F, CalculatedState](CalculatedState.empty).map { stateRef =>
       new CalculatedStateService[F] {
         override def get: F[CalculatedState] = stateRef.get
 
         override def update(
           snapshotOrdinal: SnapshotOrdinal,
-          state          : AmmCalculatedState
+          state: AmmCalculatedState
         ): F[Boolean] =
           stateRef.modify { currentState =>
             val currentCalculatedState = currentState.state
@@ -51,5 +53,4 @@ object CalculatedStateService {
         }
       }
     }
-  }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
@@ -2,23 +2,22 @@ package org.amm_metagraph.shared_data.combiners
 
 import cats.effect.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.DataState
+import io.constellationnetwork.schema.address.Address
+
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.types.DataUpdates.{AmmUpdate, LiquidityPoolUpdate}
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, LiquidityProviders, TokenInformation}
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.schema.address.Address
 
 object LiquidityPoolCombiner {
-  def combineLiquidityPool[F[_] : Async](
-    acc                : DataState[AmmOnChainState, AmmCalculatedState],
+  def combineLiquidityPool[F[_]: Async](
+    acc: DataState[AmmOnChainState, AmmCalculatedState],
     liquidityPoolUpdate: LiquidityPoolUpdate,
-    signerAddress      : Address
+    signerAddress: Address
   ): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
-    val liquidityPools = acc.calculated.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
-      case liquidityPoolCalculatedState: LiquidityPoolCalculatedState => liquidityPoolCalculatedState.liquidityPools
-      case _ => Map.empty
-    }
+    val liquidityPools = getLiquidityPools(acc)
 
     for {
       poolId <- buildLiquidityPoolUniqueIdentifier(liquidityPoolUpdate.tokenA.identifier, liquidityPoolUpdate.tokenB.identifier)
@@ -28,8 +27,14 @@ object LiquidityPoolCombiner {
 
       liquidityPool = LiquidityPool(
         poolId,
-        TokenInformation(liquidityPoolUpdate.tokenA.identifier, liquidityPoolUpdate.tokenA.amount.value.toTokenAmountFormat.toPosLongUnsafe),
-        TokenInformation(liquidityPoolUpdate.tokenB.identifier, liquidityPoolUpdate.tokenB.amount.value.toTokenAmountFormat.toPosLongUnsafe),
+        TokenInformation(
+          liquidityPoolUpdate.tokenA.identifier,
+          liquidityPoolUpdate.tokenA.amount.value.toTokenAmountFormat.toPosLongUnsafe
+        ),
+        TokenInformation(
+          liquidityPoolUpdate.tokenB.identifier,
+          liquidityPoolUpdate.tokenB.amount.value.toTokenAmountFormat.toPosLongUnsafe
+        ),
         signerAddress,
         (amountA * amountB).toDouble,
         liquidityPoolUpdate.feeRate,
@@ -39,9 +44,10 @@ object LiquidityPoolCombiner {
       updatedLiquidityPoolCalculatedState = LiquidityPoolCalculatedState(liquidityPools.updated(poolId, liquidityPool))
       updatedState = acc.calculated.ammState.updated(OperationType.LiquidityPool, updatedLiquidityPoolCalculatedState)
       updates: List[AmmUpdate] = liquidityPoolUpdate :: acc.onChain.updates
-    } yield DataState(
-      AmmOnChainState(updates),
-      AmmCalculatedState(updatedState)
-    )
+    } yield
+      DataState(
+        AmmOnChainState(updates),
+        AmmCalculatedState(updatedState)
+      )
   }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawCombiner.scala
@@ -1,26 +1,30 @@
 package org.amm_metagraph.shared_data.combiners
 
+import io.constellationnetwork.currency.dataApplication.DataState
+import io.constellationnetwork.schema.address.Address
+
 import org.amm_metagraph.shared_data.types.DataUpdates.{AmmUpdate, WithdrawUpdate}
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.Withdraw.WithdrawCalculatedStateAddress
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.schema.address.Address
 
 object WithdrawCombiner {
   def combineWithdraw(
-    acc           : DataState[AmmOnChainState, AmmCalculatedState],
+    acc: DataState[AmmOnChainState, AmmCalculatedState],
     withdrawUpdate: WithdrawUpdate,
-    signerAddress : Address
+    signerAddress: Address
   ): DataState[AmmOnChainState, AmmCalculatedState] = {
-    val withdrawCalculatedStateAddresses = acc.calculated.ammState.get(OperationType.Withdraw).fold(Map.empty[Address, WithdrawCalculatedStateAddress]) {
-      case stakingCalculatedState: WithdrawCalculatedState => stakingCalculatedState.addresses
-      case _ => Map.empty
-    }
+    val withdrawCalculatedStateAddresses =
+      acc.calculated.ammState.get(OperationType.Withdraw).fold(Map.empty[Address, WithdrawCalculatedStateAddress]) {
+        case stakingCalculatedState: WithdrawCalculatedState => stakingCalculatedState.addresses
+        case _                                               => Map.empty
+      }
     val withdrawCalculatedStateAddress = WithdrawCalculatedStateAddress(
       withdrawUpdate.amount
     )
 
-    val updatedWithdrawCalculatedState = WithdrawCalculatedState(withdrawCalculatedStateAddresses.updated(signerAddress, withdrawCalculatedStateAddress))
+    val updatedWithdrawCalculatedState = WithdrawCalculatedState(
+      withdrawCalculatedStateAddresses.updated(signerAddress, withdrawCalculatedStateAddress)
+    )
     val updatedState = acc.calculated.ammState.updated(OperationType.Withdraw, updatedWithdrawCalculatedState)
     val updates: List[AmmUpdate] = withdrawUpdate :: acc.onChain.updates
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
@@ -1,14 +1,15 @@
 package org.amm_metagraph.shared_data.types
 
+import io.constellationnetwork.currency.dataApplication.DataUpdate
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.security.hash.Hash
+
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.refined._
 import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
-import org.tessellation.currency.dataApplication.DataUpdate
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.schema.address.Address
-
 
 object DataUpdates {
   @derive(encoder, decoder)
@@ -16,36 +17,35 @@ object DataUpdates {
 
   @derive(decoder, encoder)
   case class LiquidityPoolUpdate(
-    tokenA : TokenInformation,
-    tokenB : TokenInformation,
-    feeRate: Double,
+    tokenA: TokenInformation,
+    tokenB: TokenInformation,
+    feeRate: Double
   ) extends AmmUpdate
 
   @derive(decoder, encoder)
   case class StakingUpdate(
-    primaryAllowSpendReferenceTxnId: String,
-    pairAllowSpendReferenceTxnId   : String,
-    primaryTokenId                 : Option[Address],
-    primaryTokenAmount             : PosLong,
-    pairTokenId                    : Option[Address],
+    tokenAAllowSpend: Hash,
+    tokenBAllowSpend: Hash,
+    tokenAId: Option[CurrencyId],
+    tokenAAmount: PosLong,
+    tokenBId: Option[CurrencyId]
   ) extends AmmUpdate
 
   @derive(decoder, encoder)
   case class SwapUpdate(
-    swapFromToken      : Option[Address],
-    swapToToken        : Option[Address],
-    metagraphAddress   : Address,
-    fee                : Long,
-    reference          : String,
+    swapFromToken: Option[CurrencyId],
+    swapToToken: Option[CurrencyId],
+    metagraphAddress: CurrencyId,
+    fee: Long,
+    reference: String,
     allowSpendReference: String,
-    minAmount          : PosLong,
-    maxAmount          : PosLong,
-    maxValidGsOrdinal  : SnapshotOrdinal,
-    poolId             : Option[String],
-    minPrice           : PosLong,
-    maxPrice           : PosLong
+    minAmount: PosLong,
+    maxAmount: PosLong,
+    maxValidGsOrdinal: SnapshotOrdinal,
+    poolId: Option[String],
+    minPrice: PosLong,
+    maxPrice: PosLong
   ) extends AmmUpdate
-
 
   @derive(decoder, encoder)
   case class WithdrawUpdate(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
@@ -1,17 +1,22 @@
 package org.amm_metagraph.shared_data.types
 
+import cats.effect.Async
+
+import io.constellationnetwork.currency.dataApplication.DataState
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
+
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.refined._
-import org.tessellation.schema.address.Address
-
+import org.amm_metagraph.shared_data.types.States._
 
 object LiquidityPool {
   @derive(encoder, decoder)
   case class TokenInformation(
-    identifier: Option[Address],
-    amount    : PosLong,
+    identifier: Option[CurrencyId],
+    amount: PosLong
   )
 
   @derive(encoder, decoder)
@@ -21,14 +26,19 @@ object LiquidityPool {
 
   @derive(encoder, decoder)
   case class LiquidityPool(
-    poolId            : String,
-    tokenA            : TokenInformation,
-    tokenB            : TokenInformation,
-    owner             : Address,
-    k                 : Double,
-    feeRate           : Double,
-    totalLiquidity    : Long,
+    poolId: String,
+    tokenA: TokenInformation,
+    tokenB: TokenInformation,
+    owner: Address,
+    k: Double,
+    feeRate: Double,
+    totalLiquidity: Long,
     liquidityProviders: LiquidityProviders
   )
 
+  def getLiquidityPools[F[_]: Async](state: DataState[AmmOnChainState, AmmCalculatedState]): Map[String, LiquidityPool] =
+    state.calculated.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
+      case liquidityPoolsCalculatedState: LiquidityPoolCalculatedState => liquidityPoolsCalculatedState.liquidityPools
+      case _                                                           => Map.empty
+    }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
@@ -1,29 +1,30 @@
 package org.amm_metagraph.shared_data.types
 
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
-import org.tessellation.schema.SnapshotOrdinal
-
 
 object Staking {
   @derive(encoder, decoder)
   case class StakingCalculatedStateLastReference(
-    primaryAllowSpendReferenceTxnId: String,
-    pairAllowSpendReferenceTxnId   : String,
-    primaryToken                   : TokenInformation,
-    pairToken                      : TokenInformation,
-    ordinal                        : SnapshotOrdinal
+    tokenAAllowSpend: Hash,
+    tokenBAllowSpend: Hash,
+    tokenA: TokenInformation,
+    tokenB: TokenInformation,
+    ordinal: SnapshotOrdinal
   )
 
   @derive(encoder, decoder)
   case class StakingCalculatedStateAddress(
-    primaryAllowSpendReferenceTxnId: String,
-    pairAllowSpendReferenceTxnId   : String,
-    primaryToken                   : TokenInformation,
-    pairToken                      : TokenInformation,
-    ordinal                        : SnapshotOrdinal,
-    lastStakingUpdate              : Option[StakingCalculatedStateLastReference]
+    tokenAAllowSpend: Hash,
+    tokenBAllowSpend: Hash,
+    tokenA: TokenInformation,
+    tokenB: TokenInformation,
+    ordinal: SnapshotOrdinal,
+    lastStakingUpdate: Option[StakingCalculatedStateLastReference]
   )
 
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
@@ -1,5 +1,8 @@
 package org.amm_metagraph.shared_data.types
 
+import io.constellationnetwork.currency.dataApplication.{DataCalculatedState, DataOnChainState}
+import io.constellationnetwork.schema.address.Address
+
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import enumeratum.values.{StringCirceEnum, StringEnum, StringEnumEntry}
@@ -8,8 +11,6 @@ import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress
 import org.amm_metagraph.shared_data.types.Swap.SwapCalculatedStateAddress
 import org.amm_metagraph.shared_data.types.Withdraw.WithdrawCalculatedStateAddress
-import org.tessellation.currency.dataApplication.{DataCalculatedState, DataOnChainState}
-import org.tessellation.schema.address.Address
 
 object States {
   @derive(encoder, decoder)
@@ -47,8 +48,11 @@ object States {
     val values = findValues
 
     case object Staking extends OperationType("Staking")
+
     case object Withdraw extends OperationType("Withdraw")
+
     case object LiquidityPool extends OperationType("LiquidityPool")
+
     case object Swap extends OperationType("Swap")
   }
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
@@ -1,46 +1,46 @@
 package org.amm_metagraph.shared_data.types
 
+import io.constellationnetwork.schema.SnapshotOrdinal
+
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import io.circe.refined._
 import eu.timepit.refined.types.numeric.PosLong
+import io.circe.refined._
 import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
-import org.tessellation.schema.SnapshotOrdinal
-
 
 object Swap {
 
   @derive(encoder, decoder)
   case class SwapCalculatedStateLastReference(
-    fromToken          : TokenInformation,
-    toToken            : TokenInformation,
-    fee                : Long,
-    reference          : String,
+    fromToken: TokenInformation,
+    toToken: TokenInformation,
+    fee: Long,
+    reference: String,
     allowSpendReference: String,
-    minAmount          : PosLong,
-    maxAmount          : PosLong,
-    maxValidGsOrdinal  : SnapshotOrdinal,
-    poolId             : Option[String],
-    minPrice           : PosLong,
-    maxPrice           : PosLong,
-    ordinal            : SnapshotOrdinal,
+    minAmount: PosLong,
+    maxAmount: PosLong,
+    maxValidGsOrdinal: SnapshotOrdinal,
+    poolId: Option[String],
+    minPrice: PosLong,
+    maxPrice: PosLong,
+    ordinal: SnapshotOrdinal
   )
 
   @derive(encoder, decoder)
   case class SwapCalculatedStateAddress(
-    fromToken          : TokenInformation,
-    toToken            : TokenInformation,
-    fee                : Long,
-    reference          : String,
+    fromToken: TokenInformation,
+    toToken: TokenInformation,
+    fee: Long,
+    reference: String,
     allowSpendReference: String,
-    minAmount          : PosLong,
-    maxAmount          : PosLong,
-    maxValidGsOrdinal  : SnapshotOrdinal,
-    poolId             : Option[String],
-    minPrice           : PosLong,
-    maxPrice           : PosLong,
-    ordinal            : SnapshotOrdinal,
-    lastSwapUpdate     : Option[SwapCalculatedStateLastReference]
+    minAmount: PosLong,
+    maxAmount: PosLong,
+    maxValidGsOrdinal: SnapshotOrdinal,
+    poolId: Option[String],
+    minPrice: PosLong,
+    maxPrice: PosLong,
+    ordinal: SnapshotOrdinal,
+    lastSwapUpdate: Option[SwapCalculatedStateLastReference]
   )
 
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Withdraw.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Withdraw.scala
@@ -5,11 +5,10 @@ import derevo.derive
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.refined._
 
-
 object Withdraw {
   @derive(encoder, decoder)
   case class WithdrawCalculatedStateAddress(
-    currentAmount: PosLong,
+    currentAmount: PosLong
   )
 
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/codecs/DataUpdateCodec.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/codecs/DataUpdateCodec.scala
@@ -1,14 +1,15 @@
 package org.amm_metagraph.shared_data.types.codecs
 
+import io.constellationnetwork.currency.dataApplication.DataUpdate
+
+import io.circe._
 import io.circe.syntax.EncoderOps
-import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.amm_metagraph.shared_data.types.DataUpdates.AmmUpdate
-import org.tessellation.currency.dataApplication.DataUpdate
 
 object DataUpdateCodec {
   implicit val dataUpdateEncoder: Encoder[DataUpdate] = {
     case event: AmmUpdate => event.asJson
-    case _ => Json.Null
+    case _                => Json.Null
   }
 
   implicit val dataUpdateDecoder: Decoder[DataUpdate] = (c: HCursor) => c.as[AmmUpdate]

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/codecs/JsonBinaryCodec.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/codecs/JsonBinaryCodec.scala
@@ -2,33 +2,36 @@ package org.amm_metagraph.shared_data.types.codecs
 
 import cats.effect.Sync
 import cats.syntax.all._
+
+import io.constellationnetwork.json.JsonSerializer
+
 import io.circe.jawn.JawnParser
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, Printer}
-import org.tessellation.json.JsonSerializer
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object JsonBinaryCodec {
 
-  def apply[F[_] : JsonSerializer]: JsonSerializer[F] = implicitly
+  def apply[F[_]: JsonSerializer]: JsonSerializer[F] = implicitly
 
-  def forSync[F[_] : Sync]: F[JsonSerializer[F]] = {
+  def forSync[F[_]: Sync]: F[JsonSerializer[F]] = {
     def printer = Printer(dropNullValues = true, indent = "", sortKeys = true)
 
     forSync[F](printer)
   }
 
-  def forSync[F[_] : Sync](printer: Printer): F[JsonSerializer[F]] =
+  def forSync[F[_]: Sync](printer: Printer): F[JsonSerializer[F]] =
     Sync[F].delay {
       new JsonSerializer[F] {
         def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("JsonSerializer")
-        override def serialize[A: Encoder](content: A): F[Array[Byte]] = {
-          logger.info(s"Serialized JSON: ${content.asJson.printWith(printer)}").as(
-          content.asJson.printWith(printer).getBytes("UTF-8")
-          )
-        }
 
+        override def serialize[A: Encoder](content: A): F[Array[Byte]] =
+          logger
+            .info(s"Serialized JSON: ${content.asJson.printWith(printer)}")
+            .as(
+              content.asJson.printWith(printer).getBytes("UTF-8")
+            )
 
         override def deserialize[A: Decoder](content: Array[Byte]): F[Either[Throwable, A]] =
           Sync[F].delay(JawnParser(false).decodeByteArray[A](content))

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -1,8 +1,9 @@
 package org.amm_metagraph.shared_data.validations
 
 import cats.syntax.all._
-import org.tessellation.currency.dataApplication.DataApplicationValidationError
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+
+import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 object Errors {
   private type DataApplicationValidationType = DataApplicationValidationErrorOr[Unit]
@@ -31,6 +32,18 @@ object Errors {
 
   case object StakingLiquidityPoolDoesNotExists extends DataApplicationValidationError {
     val message = "Staking liquidity pool does not exists"
+  }
+
+  case object StakingMissingAllowSpend extends DataApplicationValidationError {
+    val message = "Missing one or both allow spends to stake"
+  }
+
+  case object StakingDifferentAllowSpendSource extends DataApplicationValidationError {
+    val message = "Different allow spend sources"
+  }
+
+  case object StakingDifferentAllowSpendDestination extends DataApplicationValidationError {
+    val message = "Different allow spend destination"
   }
 
   case object StakingInvalidTokenPair extends DataApplicationValidationError {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
@@ -2,48 +2,48 @@ package org.amm_metagraph.shared_data.validations
 
 import cats.effect.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+
 import org.amm_metagraph.shared_data.Utils.buildLiquidityPoolUniqueIdentifier
+import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
 import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, LiquidityPoolCalculatedState, OperationType}
-import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
 import org.amm_metagraph.shared_data.validations.Errors.{LiquidityPoolAlreadyExists, LiquidityPoolNotEnoughInformation}
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 object LiquidityPoolValidations {
-  def liquidityPoolValidationsL1[F[_] : Async](
-    liquidityPoolUpdate: LiquidityPoolUpdate,
+  def liquidityPoolValidationsL1[F[_]: Async](
+    liquidityPoolUpdate: LiquidityPoolUpdate
   ): F[DataApplicationValidationErrorOr[Unit]] = Async[F].delay {
     LiquidityPoolValidations.validateIfTokensArePresent(liquidityPoolUpdate)
   }
 
-  def liquidityPoolValidationsL0[F[_] : Async](
+  def liquidityPoolValidationsL0[F[_]: Async](
     liquidityPoolUpdate: LiquidityPoolUpdate,
-    state              : AmmCalculatedState
-  ): F[DataApplicationValidationErrorOr[Unit]] = {
+    state: AmmCalculatedState
+  ): F[DataApplicationValidationErrorOr[Unit]] =
     for {
       liquidityPoolValidationsL1 <- liquidityPoolValidationsL1(liquidityPoolUpdate)
       calculatedState = state.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
         case liquidityPoolCalculatedState: LiquidityPoolCalculatedState => liquidityPoolCalculatedState.liquidityPools
-        case _ => Map.empty[String, LiquidityPool]
+        case _                                                          => Map.empty[String, LiquidityPool]
       }
       poolAlreadyExists <- validateIfPoolAlreadyExists(
         liquidityPoolUpdate,
         calculatedState
       ).handleErrorWith(_ => LiquidityPoolNotEnoughInformation.whenA(true).pure)
     } yield liquidityPoolValidationsL1.productR(poolAlreadyExists)
-  }
 
   private def validateIfTokensArePresent(
     liquidityPoolUpdate: LiquidityPoolUpdate
   ): DataApplicationValidationErrorOr[Unit] =
     LiquidityPoolNotEnoughInformation.whenA(liquidityPoolUpdate.tokenA.identifier.isEmpty && liquidityPoolUpdate.tokenB.identifier.isEmpty)
 
-  private def validateIfPoolAlreadyExists[F[_] : Async](
-    liquidityPoolUpdate  : LiquidityPoolUpdate,
+  private def validateIfPoolAlreadyExists[F[_]: Async](
+    liquidityPoolUpdate: LiquidityPoolUpdate,
     currentLiquidityPools: Map[String, LiquidityPool]
-  ): F[DataApplicationValidationErrorOr[Unit]] = {
+  ): F[DataApplicationValidationErrorOr[Unit]] =
     for {
       poolId <- buildLiquidityPoolUniqueIdentifier(liquidityPoolUpdate.tokenA.identifier, liquidityPoolUpdate.tokenB.identifier)
     } yield LiquidityPoolAlreadyExists.whenA(currentLiquidityPools.contains(poolId))
-  }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
@@ -3,64 +3,87 @@ package org.amm_metagraph.shared_data.validations
 import cats.data.NonEmptySet
 import cats.effect.Async
 import cats.syntax.all._
-import org.amm_metagraph.shared_data.Utils.{buildLiquidityPoolUniqueIdentifier, toAddress}
-import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
+
+import io.constellationnetwork.currency.dataApplication.L0NodeContext
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.security.signature.signature.SignatureProof
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import org.amm_metagraph.shared_data.Utils.{buildLiquidityPoolUniqueIdentifier, getAllowSpendsLastSyncGlobalSnapshotState, toAddress}
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
+import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress
-import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, LiquidityPoolCalculatedState, OperationType, StakingCalculatedState}
+import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.validations.Errors._
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.schema.address.Address
-import org.tessellation.security.SecurityProvider
-import org.tessellation.security.signature.signature.SignatureProof
 
 object StakingValidations {
-  def stakingValidationsL1[F[_] : Async](
-    stakingUpdate: StakingUpdate,
+  def stakingValidationsL1[F[_]: Async](
+    stakingUpdate: StakingUpdate
   ): F[DataApplicationValidationErrorOr[Unit]] =
     valid.pure
 
-  def stakingValidationsL0[F[_] : Async](
+  def stakingValidationsL0[F[_]: Async: Hasher](
     stakingUpdate: StakingUpdate,
-    state        : AmmCalculatedState,
-    proofs       : NonEmptySet[SignatureProof]
-  )(implicit sp: SecurityProvider[F]): F[DataApplicationValidationErrorOr[Unit]] = {
-    for {
-      address <- toAddress(proofs.head)
-      stakingCalculatedState = state.ammState.get(OperationType.Staking).fold(Map.empty[Address, StakingCalculatedStateAddress]) {
-        case stakingCalculatedState: StakingCalculatedState => stakingCalculatedState.addresses
-        case _ => Map.empty[Address, StakingCalculatedStateAddress]
-      }
-      liquidityPoolsCalculatedState = state.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
-        case liquidityPoolCalculatedState: LiquidityPoolCalculatedState => liquidityPoolCalculatedState.liquidityPools
-        case _ => Map.empty[String, LiquidityPool]
-      }
+    state: AmmCalculatedState,
+    proofs: NonEmptySet[SignatureProof]
+  )(implicit sp: SecurityProvider[F], context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] = for {
+    address <- toAddress(proofs.head)
 
-      transactionAlreadyExists = validateIfTransactionAlreadyExists(
-        stakingUpdate,
-        stakingCalculatedState.get(address)
-      )
-      liquidityPoolExists <- validateIfLiquidityPoolExists(
-        stakingUpdate,
-        liquidityPoolsCalculatedState
-      )
-      stakingValidationsL1 <- stakingValidationsL1(stakingUpdate)
-      result = stakingValidationsL1.productR(transactionAlreadyExists).productR(liquidityPoolExists)
-    } yield result
-  }
+    stakingCalculatedState = state.ammState.get(OperationType.Staking).fold(Map.empty[Address, StakingCalculatedStateAddress]) {
+      case stakingCalculatedState: StakingCalculatedState => stakingCalculatedState.addresses
+      case _                                              => Map.empty[Address, StakingCalculatedStateAddress]
+    }
+    liquidityPoolsCalculatedState = state.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
+      case liquidityPoolCalculatedState: LiquidityPoolCalculatedState => liquidityPoolCalculatedState.liquidityPools
+      case _                                                          => Map.empty[String, LiquidityPool]
+    }
+
+    validAllowSpends <- validateStakingAllowSpends(
+      stakingUpdate
+    )
+    transactionAlreadyExists = validateIfTransactionAlreadyExists(
+      stakingUpdate,
+      stakingCalculatedState.get(address)
+    )
+    liquidityPoolExists <- validateIfLiquidityPoolExists(
+      stakingUpdate,
+      liquidityPoolsCalculatedState
+    )
+
+    result = validAllowSpends.productR(transactionAlreadyExists).productR(liquidityPoolExists)
+  } yield result
 
   private def validateIfTransactionAlreadyExists(
-    stakingUpdate                     : StakingUpdate,
+    stakingUpdate: StakingUpdate,
     maybeStakingCalculatedStateAddress: Option[StakingCalculatedStateAddress]
   ): DataApplicationValidationErrorOr[Unit] =
-    StakingTransactionAlreadyExists.whenA(maybeStakingCalculatedStateAddress.exists(_.primaryAllowSpendReferenceTxnId == stakingUpdate.primaryAllowSpendReferenceTxnId))
+    StakingTransactionAlreadyExists.whenA(maybeStakingCalculatedStateAddress.exists(_.tokenAAllowSpend == stakingUpdate.tokenBAllowSpend))
 
-  private def validateIfLiquidityPoolExists[F[_] : Async](
-    stakingUpdate        : StakingUpdate,
+  private def validateIfLiquidityPoolExists[F[_]: Async](
+    stakingUpdate: StakingUpdate,
     currentLiquidityPools: Map[String, LiquidityPool]
   ): F[DataApplicationValidationErrorOr[Unit]] = for {
-    poolId <- buildLiquidityPoolUniqueIdentifier(stakingUpdate.primaryTokenId, stakingUpdate.pairTokenId)
+    poolId <- buildLiquidityPoolUniqueIdentifier(stakingUpdate.tokenAId, stakingUpdate.tokenBId)
     result = StakingLiquidityPoolDoesNotExists.unlessA(currentLiquidityPools.contains(poolId))
   } yield result
 
+  private def validateStakingAllowSpends[F[_]: Async: Hasher](
+    stakingUpdate: StakingUpdate
+  )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
+    getAllowSpendsLastSyncGlobalSnapshotState(
+      stakingUpdate.tokenAAllowSpend,
+      stakingUpdate.tokenBAllowSpend
+    ).map { allowSpends =>
+      val (tokenAAllowSpend, tokenBAllowSpend) = allowSpends
+      if (tokenAAllowSpend.isEmpty || tokenBAllowSpend.isEmpty) {
+        StakingMissingAllowSpend.invalid
+      } else if (tokenAAllowSpend.get.source != tokenBAllowSpend.get.source) {
+        StakingDifferentAllowSpendSource.invalid
+      } else if (tokenAAllowSpend.get.destination != tokenBAllowSpend.get.destination) {
+        StakingDifferentAllowSpendDestination.invalid
+      } else {
+        valid
+      }
+    }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SwapValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SwapValidations.scala
@@ -2,27 +2,29 @@ package org.amm_metagraph.shared_data.validations
 
 import cats.effect.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+
 import org.amm_metagraph.shared_data.Utils.buildLiquidityPoolUniqueIdentifier
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
 import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, LiquidityPoolCalculatedState, OperationType}
 import org.amm_metagraph.shared_data.validations.Errors._
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 object SwapValidations {
-  def swapValidationsL1[F[_] : Async](
-    stakingUpdate: SwapUpdate,
+  def swapValidationsL1[F[_]: Async](
+    stakingUpdate: SwapUpdate
   ): F[DataApplicationValidationErrorOr[Unit]] = Async[F].delay {
     valid
   }
 
-  def swapValidationsL0[F[_] : Async](
+  def swapValidationsL0[F[_]: Async](
     swapUpdate: SwapUpdate,
-    state     : AmmCalculatedState
+    state: AmmCalculatedState
   ): F[DataApplicationValidationErrorOr[Unit]] = {
     val liquidityPoolsCalculatedState = state.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
       case liquidityPoolCalculatedState: LiquidityPoolCalculatedState => liquidityPoolCalculatedState.liquidityPools
-      case _ => Map.empty[String, LiquidityPool]
+      case _                                                          => Map.empty[String, LiquidityPool]
     }
 
     for {
@@ -41,23 +43,23 @@ object SwapValidations {
     } yield result
   }
 
-  private def validateIfLiquidityPoolExists[F[_] : Async](
-    swapUpdate           : SwapUpdate,
+  private def validateIfLiquidityPoolExists[F[_]: Async](
+    swapUpdate: SwapUpdate,
     currentLiquidityPools: Map[String, LiquidityPool]
   ): F[DataApplicationValidationErrorOr[Unit]] = for {
     poolId <- buildLiquidityPoolUniqueIdentifier(swapUpdate.swapFromToken, swapUpdate.swapToToken)
     result = SwapLiquidityPoolDoesNotExists.unlessA(currentLiquidityPools.contains(poolId))
   } yield result
 
-  private def validateIfPoolHaveEnoughTokens[F[_] : Async](
-    swapUpdate           : SwapUpdate,
+  private def validateIfPoolHaveEnoughTokens[F[_]: Async](
+    swapUpdate: SwapUpdate,
     currentLiquidityPools: Map[String, LiquidityPool]
   ): F[DataApplicationValidationErrorOr[Unit]] = {
     val hasEnoughTokens: LiquidityPool => Boolean = lp => {
       val maybeToken = swapUpdate.swapToToken match {
         case None => Option.when(lp.tokenA.identifier.isEmpty)(lp.tokenA).orElse(lp.tokenB.some)
         case Some(value) if lp.tokenA.identifier.contains(value) => lp.tokenA.some
-        case Some(value) => Option.when(lp.tokenB.identifier.contains(value))(lp.tokenB)
+        case Some(value)                                         => Option.when(lp.tokenB.identifier.contains(value))(lp.tokenB)
       }
       maybeToken.exists(_.amount.value > swapUpdate.maxAmount.value)
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
@@ -3,16 +3,18 @@ package org.amm_metagraph.shared_data.validations
 import cats.data.NonEmptyList
 import cats.effect.kernel.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.validations.LiquidityPoolValidations.{liquidityPoolValidationsL0, liquidityPoolValidationsL1}
 import org.amm_metagraph.shared_data.validations.StakingValidations.{stakingValidationsL0, stakingValidationsL1}
 import org.amm_metagraph.shared_data.validations.SwapValidations.{swapValidationsL0, swapValidationsL1}
 import org.amm_metagraph.shared_data.validations.WithdrawValidations.{withdrawValidationsL0, withdrawValidationsL1}
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.security.SecurityProvider
-import org.tessellation.security.signature.Signed
 
 trait ValidationService[F[_]] {
   def validateUpdate(
@@ -21,25 +23,28 @@ trait ValidationService[F[_]] {
 
   def validateData(
     signedUpdates: NonEmptyList[Signed[AmmUpdate]],
-    state        : DataState[AmmOnChainState, AmmCalculatedState]
-  ): F[DataApplicationValidationErrorOr[Unit]]
+    state: DataState[AmmOnChainState, AmmCalculatedState]
+  )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]]
 }
 
 object ValidationService {
-  def make[F[_] : Async : SecurityProvider]: F[ValidationService[F]] = Async[F].delay {
+  def make[F[_]: Async: SecurityProvider: Hasher]: F[ValidationService[F]] = Async[F].delay {
     new ValidationService[F] {
       private def validateL1(update: AmmUpdate): F[DataApplicationValidationErrorOr[Unit]] = update match {
-        case stakingUpdate: StakingUpdate => stakingValidationsL1(stakingUpdate)
-        case withdrawUpdate: WithdrawUpdate => withdrawValidationsL1(withdrawUpdate)
+        case stakingUpdate: StakingUpdate             => stakingValidationsL1(stakingUpdate)
+        case withdrawUpdate: WithdrawUpdate           => withdrawValidationsL1(withdrawUpdate)
         case liquidityPoolUpdate: LiquidityPoolUpdate => liquidityPoolValidationsL1(liquidityPoolUpdate)
-        case swapUpdate: SwapUpdate => swapValidationsL1(swapUpdate)
+        case swapUpdate: SwapUpdate                   => swapValidationsL1(swapUpdate)
       }
 
-      private def validateL0(signedUpdate: Signed[AmmUpdate], state: AmmCalculatedState): F[DataApplicationValidationErrorOr[Unit]] = signedUpdate.value match {
-        case stakingUpdate: StakingUpdate => stakingValidationsL0(stakingUpdate, state, signedUpdate.proofs)
-        case withdrawUpdate: WithdrawUpdate => withdrawValidationsL0(withdrawUpdate, state)
+      private def validateL0(
+        signedUpdate: Signed[AmmUpdate],
+        state: AmmCalculatedState
+      )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] = signedUpdate.value match {
+        case stakingUpdate: StakingUpdate             => stakingValidationsL0(stakingUpdate, state, signedUpdate.proofs)
+        case withdrawUpdate: WithdrawUpdate           => withdrawValidationsL0(withdrawUpdate, state)
         case liquidityPoolUpdate: LiquidityPoolUpdate => liquidityPoolValidationsL0(liquidityPoolUpdate, state)
-        case swapUpdate: SwapUpdate => swapValidationsL0(swapUpdate, state)
+        case swapUpdate: SwapUpdate                   => swapValidationsL0(swapUpdate, state)
       }
 
       override def validateUpdate(
@@ -48,8 +53,8 @@ object ValidationService {
 
       override def validateData(
         signedUpdates: NonEmptyList[Signed[AmmUpdate]],
-        state        : DataState[AmmOnChainState, AmmCalculatedState]
-      ): F[DataApplicationValidationErrorOr[Unit]] = signedUpdates
+        state: DataState[AmmOnChainState, AmmCalculatedState]
+      )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] = signedUpdates
         .traverse(validateL0(_, state.calculated))
         .map(_.combineAll)
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/WithdrawValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/WithdrawValidations.scala
@@ -2,19 +2,21 @@ package org.amm_metagraph.shared_data.validations
 
 import cats.effect.Async
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.security.SecurityProvider
+
 import org.amm_metagraph.shared_data.types.DataUpdates.WithdrawUpdate
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 import org.amm_metagraph.shared_data.validations.Errors.valid
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.security.SecurityProvider
 
 object WithdrawValidations {
-  def withdrawValidationsL1[F[_] : Async](
-    withdrawUpdate: WithdrawUpdate,
+  def withdrawValidationsL1[F[_]: Async](
+    withdrawUpdate: WithdrawUpdate
   ): F[DataApplicationValidationErrorOr[Unit]] = valid.pure
 
-  def withdrawValidationsL0[F[_] : Async : SecurityProvider](
+  def withdrawValidationsL0[F[_]: Async: SecurityProvider](
     withdrawUpdate: WithdrawUpdate,
-    state         : AmmCalculatedState
+    state: AmmCalculatedState
   ): F[DataApplicationValidationErrorOr[Unit]] = valid.pure
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
@@ -1,0 +1,73 @@
+package com.my.dor_metagraph.shared_data
+
+import java.security.KeyPair
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.currency.dataApplication.L0NodeContext
+import io.constellationnetwork.currency.schema.currency
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap.AllowSpend
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
+
+import eu.timepit.refined.auto._
+
+object DummyL0Context {
+  val metagraphAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
+
+  def buildGlobalIncrementalSnapshot[F[_]: Async: SecurityProvider](
+    keyPair: KeyPair
+  )(
+    implicit hs: Hasher[F]
+  ): F[Hashed[GlobalIncrementalSnapshot]] =
+    GlobalIncrementalSnapshot
+      .fromGlobalSnapshot[F](
+        GlobalSnapshot.mkGenesis(Map.empty, EpochProgress.MinValue)
+      )
+      .flatMap { globalIncrementalSnapshot =>
+        Signed
+          .forAsyncHasher[F, GlobalIncrementalSnapshot](globalIncrementalSnapshot, keyPair)
+          .flatMap(_.toHashed[F])
+      }
+
+  def buildGlobalSnapshotInfo(activeAllowSpends: SortedMap[Address, SortedSet[Signed[AllowSpend]]]): GlobalSnapshotInfo =
+    GlobalSnapshotInfo(
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap.empty,
+      SortedMap(metagraphAddress -> activeAllowSpends)
+    )
+
+  def buildL0NodeContext[F[_]: Async: Hasher: SecurityProvider](
+    keyPair: KeyPair,
+    allowSpends: SortedMap[Address, SortedSet[Signed[AllowSpend]]]
+  ): L0NodeContext[F] =
+    new L0NodeContext[F] {
+      override def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
+
+      override def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = for {
+        globalIncrementalSnapshot <- buildGlobalIncrementalSnapshot[F](keyPair)
+        globalSnapshotInfo = buildGlobalSnapshotInfo(allowSpends)
+      } yield Some((globalIncrementalSnapshot, globalSnapshotInfo))
+
+      override def getLastCurrencySnapshot: F[Option[Hashed[currency.CurrencyIncrementalSnapshot]]] = ???
+
+      override def getCurrencySnapshot(ordinal: SnapshotOrdinal): F[Option[Hashed[currency.CurrencyIncrementalSnapshot]]] = ???
+
+      override def getLastCurrencySnapshotCombined
+        : F[Option[(Hashed[currency.CurrencyIncrementalSnapshot], currency.CurrencySnapshotInfo)]] = ???
+
+      override def securityProvider: SecurityProvider[F] = ???
+
+      override def getMetagraphId: F[Address] = metagraphAddress.pure[F]
+    }
+
+}

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -2,21 +2,24 @@ package com.my.dor_metagraph.shared_data.combiners
 
 import cats.effect.IO
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.DataState
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
+
 import eu.timepit.refined.auto._
 import org.amm_metagraph.shared_data.Utils.{LongOps, buildLiquidityPoolUniqueIdentifier}
 import org.amm_metagraph.shared_data.combiners.LiquidityPoolCombiner.combineLiquidityPool
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.schema.address.Address
 import weaver.SimpleIOSuite
 
 object LiquidityPoolCombinerTest extends SimpleIOSuite {
 
-  test("Successfully create a liquidity pool - L0Token - L0Token") {
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+  test("Successfully create a liquidity pool") {
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
     val ammOnChainState = AmmOnChainState(List.empty)
     val ammCalculatedState = AmmCalculatedState(Map.empty)
@@ -34,17 +37,20 @@ object LiquidityPoolCombinerTest extends SimpleIOSuite {
         ownerAddress
       )
       poolId <- buildLiquidityPoolUniqueIdentifier(primaryToken.identifier, pairToken.identifier)
-      updatedLiquidityPoolCalculatedState = stakeResponse.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      updatedLiquidityPoolCalculatedState = stakeResponse.calculated
+        .ammState(OperationType.LiquidityPool)
+        .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
-    } yield expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-      expect.eql(primaryToken.identifier.get, updatedLiquidityPool.tokenA.identifier.get) &&
-      expect.eql(50L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
-      expect.eql(pairToken.identifier.get, updatedLiquidityPool.tokenB.identifier.get) &&
-      expect.eql(5000D, updatedLiquidityPool.k)
+    } yield
+      expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
+        expect.eql(primaryToken.identifier.get, updatedLiquidityPool.tokenA.identifier.get) &&
+        expect.eql(50L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
+        expect.eql(pairToken.identifier.get, updatedLiquidityPool.tokenB.identifier.get) &&
+        expect.eql(5000d, updatedLiquidityPool.k)
   }
 
   test("Successfully create a liquidity pool - L0Token - DAG") {
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
     val pairToken = TokenInformation(none, 50L)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
     val ammOnChainState = AmmOnChainState(List.empty)
@@ -63,12 +69,15 @@ object LiquidityPoolCombinerTest extends SimpleIOSuite {
         ownerAddress
       )
       poolId <- buildLiquidityPoolUniqueIdentifier(primaryToken.identifier, pairToken.identifier)
-      updatedLiquidityPoolCalculatedState = stakeResponse.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      updatedLiquidityPoolCalculatedState = stakeResponse.calculated
+        .ammState(OperationType.LiquidityPool)
+        .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
-    } yield expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-      expect.eql(primaryToken.identifier.get, updatedLiquidityPool.tokenA.identifier.get) &&
-      expect.eql(50L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
-      expect.eql(pairToken.identifier.isEmpty, updatedLiquidityPool.tokenB.identifier.isEmpty) &&
-      expect.eql(5000D, updatedLiquidityPool.k)
+    } yield
+      expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
+        expect.eql(primaryToken.identifier.get, updatedLiquidityPool.tokenA.identifier.get) &&
+        expect.eql(50L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
+        expect.eql(pairToken.identifier.isEmpty, updatedLiquidityPool.tokenB.identifier.isEmpty) &&
+        expect.eql(5000d, updatedLiquidityPool.k)
   }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
@@ -1,24 +1,45 @@
 package com.my.dor_metagraph.shared_data.combiners
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.syntax.all._
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.security._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+
+import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.PosLong
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.combiners.StakingCombiner.combineStaking
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, LiquidityProviders, TokenInformation}
 import org.amm_metagraph.shared_data.types.States._
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.schema.address.Address
-import weaver.SimpleIOSuite
+import weaver.MutableIOSuite
 
-object StakingCombinerTest extends SimpleIOSuite {
+object StakingCombinerTest extends MutableIOSuite {
+
+  type Res = (Hasher[IO], SecurityProvider[IO])
+
+  override def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h = Hasher.forJson[IO]
+  } yield (h, sp)
 
   def buildLiquidityPoolCalculatedState(
     tokenA: TokenInformation,
     tokenB: TokenInformation,
-    owner : Address
+    owner: Address
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
     val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
@@ -36,26 +57,63 @@ object StakingCombinerTest extends SimpleIOSuite {
     (poolId, LiquidityPoolCalculatedState(Map(poolId -> liquidityPool)))
   }
 
-  test("Test combining successfully when liquidity pool exists") {
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
-    val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
+  test("Test combining successfully when liquidity pool exists") { implicit res =>
+    implicit val (h, sp) = res
 
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
+    val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
     val (poolId, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress)
     val ammOnChainState = AmmOnChainState(List.empty)
     val ammCalculatedState = AmmCalculatedState(
       Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
     )
     val state = DataState(ammOnChainState, ammCalculatedState)
-    val stakingUpdate = StakingUpdate(
-      "fake-primary-txn-1",
-      "fake-pair-txn-1",
-      primaryToken.identifier,
-      100L.toPosLongUnsafe,
-      pairToken.identifier
-    )
-
     for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      allowSpendTokenA = AllowSpend(
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc"),
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb"),
+        none,
+        SwapAmount(PosLong.MinValue),
+        AllowSpendFee(PosLong.MinValue),
+        AllowSpendReference(AllowSpendOrdinal.first, Hash.empty),
+        EpochProgress.MaxValue,
+        List.empty
+      )
+      allowSpendTokenB = AllowSpend(
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc"),
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb"),
+        none,
+        SwapAmount(PosLong.MaxValue),
+        AllowSpendFee(PosLong.MinValue),
+        AllowSpendReference(AllowSpendOrdinal.first, Hash.empty),
+        EpochProgress.MaxValue,
+        List.empty
+      )
+
+      signedAllowSpendA <- Signed
+        .forAsyncHasher[IO, AllowSpend](allowSpendTokenA, keyPair)
+        .flatMap(_.toHashed[IO])
+      signedAllowSpendB <- Signed
+        .forAsyncHasher[IO, AllowSpend](allowSpendTokenB, keyPair)
+        .flatMap(_.toHashed[IO])
+
+      stakingUpdate = StakingUpdate(
+        signedAllowSpendA.hash,
+        signedAllowSpendB.hash,
+        primaryToken.identifier,
+        100L.toPosLongUnsafe,
+        pairToken.identifier
+      )
+
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
+        keyPair,
+        SortedMap(
+          Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc") -> SortedSet(signedAllowSpendA.signed, signedAllowSpendB.signed)
+        )
+      )
+
       stakeResponse <- combineStaking[IO](
         state,
         stakingUpdate,
@@ -69,47 +127,67 @@ object StakingCombinerTest extends SimpleIOSuite {
       oldLiquidityPoolCalculatedState = state.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
       oldLiquidityPool = oldLiquidityPoolCalculatedState.liquidityPools(poolId)
 
-      updatedLiquidityPoolCalculatedState = stakeResponse.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      updatedLiquidityPoolCalculatedState = stakeResponse.calculated
+        .ammState(OperationType.LiquidityPool)
+        .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
-    } yield expect.eql(100L.toTokenAmountFormat, addressStakedResponse.primaryToken.amount.value) &&
-      expect.eql(primaryToken.identifier.get, addressStakedResponse.primaryToken.identifier.get) &&
-      expect.eql(50L.toTokenAmountFormat, addressStakedResponse.pairToken.amount.value) &&
-      expect.eql(pairToken.identifier.get, addressStakedResponse.pairToken.identifier.get) &&
-      expect.eql(100L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
-      expect.eql(200L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-      expect.eql(50L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
-      expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
-      expect.eql(5000D, oldLiquidityPool.k) &&
-      expect.eql(20000D, updatedLiquidityPool.k)
+
+      stakingSpendTransactions = stakeResponse.sharedArtifacts.collect {
+        case transaction: artifact.SpendTransaction => transaction
+      }.collect {
+        case transaction: artifact.PendingSpendTransaction => transaction
+      }
+      tokenASpendTransaction = stakingSpendTransactions.find(_.allowSpendRef === signedAllowSpendA.hash)
+      tokenBSpendTransaction = stakingSpendTransactions.find(_.allowSpendRef === signedAllowSpendB.hash)
+
+    } yield
+      expect.eql(100L.toTokenAmountFormat, addressStakedResponse.tokenA.amount.value) &&
+        expect.eql(primaryToken.identifier.get, addressStakedResponse.tokenA.identifier.get) &&
+        expect.eql(50L.toTokenAmountFormat, addressStakedResponse.tokenB.amount.value) &&
+        expect.eql(pairToken.identifier.get, addressStakedResponse.tokenB.identifier.get) &&
+        expect.eql(100L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
+        expect.eql(200L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
+        expect.eql(50L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
+        expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
+        expect.eql(5000d, oldLiquidityPool.k) &&
+        expect.eql(20000d, updatedLiquidityPool.k) &&
+        expect.eql(allowSpendTokenA.amount.value.value, tokenASpendTransaction.get.amount.value.value) &&
+        expect.eql(allowSpendTokenB.amount.value.value, tokenBSpendTransaction.get.amount.value.value)
   }
 
-  test("Throws error if liquidity pool does not exists") {
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+  test("Throws error if liquidity pool does not exists") { implicit res =>
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
 
     val ammOnChainState = AmmOnChainState(List.empty)
     val ammCalculatedState = AmmCalculatedState(Map.empty)
     val state = DataState(ammOnChainState, ammCalculatedState)
     val stakingUpdate = StakingUpdate(
-      "fake-primary-txn-1",
-      "fake-pair-txn-1",
+      Hash.empty,
+      Hash.empty,
       primaryToken.identifier,
       100L.toPosLongUnsafe,
       pairToken.identifier
     )
-    combineStaking[IO](
-      state,
-      stakingUpdate,
-      ownerAddress,
-      SnapshotOrdinal.MinValue
-    ).attempt.map {
-      case Left(e: IllegalStateException) =>
-        expect(e.getMessage == "Liquidity Pool does not exists")
-      case Left(e) =>
-        failure(s"Unexpected exception: $e")
-      case Right(_) =>
-        failure("Expected exception was not thrown")
-    }
+    for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
+      result <- combineStaking[IO](
+        state,
+        stakingUpdate,
+        ownerAddress,
+        SnapshotOrdinal.MinValue
+      ).attempt.map {
+        case Left(e: IllegalStateException) =>
+          expect(e.getMessage == "Liquidity Pool does not exists")
+        case Left(e) =>
+          failure(s"Unexpected exception: $e")
+        case Right(_) =>
+          failure("Expected exception was not thrown")
+      }
+    } yield result
   }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -2,22 +2,25 @@ package com.my.dor_metagraph.shared_data.combiners
 
 import cats.effect.IO
 import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.DataState
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
+
 import eu.timepit.refined.auto._
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.combiners.SwapCombiner.combineSwap
-import org.amm_metagraph.shared_data.types.DataUpdates._
+import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.schema.address.Address
 import weaver.SimpleIOSuite
 
 object SwapCombinerTest extends SimpleIOSuite {
   def buildLiquidityPoolCalculatedState(
     tokenA: TokenInformation,
     tokenB: TokenInformation,
-    owner : Address,
+    owner: Address,
     feeRate: Long
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
@@ -29,7 +32,7 @@ object SwapCombinerTest extends SimpleIOSuite {
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      (feeRate.toDouble / 100D),
+      feeRate.toDouble / 100d,
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
@@ -37,8 +40,10 @@ object SwapCombinerTest extends SimpleIOSuite {
   }
 
   test("Test swap successfully when liquidity pool exists 3% fee") {
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 2000000L.toTokenAmountFormat.toPosLongUnsafe)
+    val primaryToken =
+      TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
+    val pairToken =
+      TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 2000000L.toTokenAmountFormat.toPosLongUnsafe)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
     val metagraphAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Gs")
 
@@ -51,7 +56,7 @@ object SwapCombinerTest extends SimpleIOSuite {
     val stakingUpdate = SwapUpdate(
       primaryToken.identifier,
       pairToken.identifier,
-      metagraphAddress,
+      CurrencyId(metagraphAddress),
       0L,
       "",
       "",
@@ -77,20 +82,25 @@ object SwapCombinerTest extends SimpleIOSuite {
       oldLiquidityPoolCalculatedState = state.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
       oldLiquidityPool = oldLiquidityPoolCalculatedState.liquidityPools(poolId)
 
-      updatedLiquidityPoolCalculatedState = stakeResponse.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      updatedLiquidityPoolCalculatedState = stakeResponse.calculated
+        .ammState(OperationType.LiquidityPool)
+        .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
-    } yield expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
-      expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
-      expect.eql(1823154.05651777, addressSwapResponse.toToken.amount.value.fromTokenAmountFormat) &&
-      expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
-      expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
-      expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-      expect.eql(1823154.05651777.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value)
+    } yield
+      expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
+        expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
+        expect.eql(1823154.05651777, addressSwapResponse.toToken.amount.value.fromTokenAmountFormat) &&
+        expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
+        expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
+        expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
+        expect.eql(1823154.05651777.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value)
   }
 
   test("Test swap successfully when liquidity pool exists - 10% fee") {
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 2000000L.toTokenAmountFormat.toPosLongUnsafe)
+    val primaryToken =
+      TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
+    val pairToken =
+      TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 2000000L.toTokenAmountFormat.toPosLongUnsafe)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
     val metagraphAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Gs")
 
@@ -103,7 +113,7 @@ object SwapCombinerTest extends SimpleIOSuite {
     val stakingUpdate = SwapUpdate(
       primaryToken.identifier,
       pairToken.identifier,
-      metagraphAddress,
+      CurrencyId(metagraphAddress),
       0L,
       "",
       "",
@@ -129,14 +139,17 @@ object SwapCombinerTest extends SimpleIOSuite {
       oldLiquidityPoolCalculatedState = state.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
       oldLiquidityPool = oldLiquidityPoolCalculatedState.liquidityPools(poolId)
 
-      updatedLiquidityPoolCalculatedState = stakeResponse.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      updatedLiquidityPoolCalculatedState = stakeResponse.calculated
+        .ammState(OperationType.LiquidityPool)
+        .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
-    } yield expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
-      expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
-      expect.eql(1834862.3853211, addressSwapResponse.toToken.amount.value.fromTokenAmountFormat) &&
-      expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
-      expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
-      expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-      expect.eql(1834862.3853211.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value)
+    } yield
+      expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
+        expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
+        expect.eql(1834862.3853211, addressSwapResponse.toToken.amount.value.fromTokenAmountFormat) &&
+        expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
+        expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
+        expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
+        expect.eql(1834862.3853211.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value)
   }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
@@ -5,30 +5,43 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, NonEmptySet}
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
-import com.my.dor_metagraph.shared_data.validations.StakingValidationTest.buildLiquidityPoolCalculatedState
+
+import scala.collection.immutable.SortedMap
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvider}
+
+import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import org.amm_metagraph.shared_data.Utils.{DoubleOps, LongOps}
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool._
-import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, AmmOnChainState, LiquidityPoolCalculatedState, OperationType}
+import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.validations.{Errors, ValidationService}
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.schema.ID.Id
-import org.tessellation.schema.address.Address
-import org.tessellation.security.SecurityProvider
-import org.tessellation.security.hex.Hex
-import org.tessellation.security.signature.Signed
-import org.tessellation.security.signature.signature.{Signature, SignatureProof}
 import weaver.MutableIOSuite
 
 object LiquidityPoolValidationTest extends MutableIOSuite {
-  type Res = SecurityProvider[IO]
+  type Res = (Hasher[IO], SecurityProvider[IO])
+
+  override def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h = Hasher.forJson[IO]
+  } yield (h, sp)
 
   def buildLiquidityPoolCalculatedState(
-    tokenA : TokenInformation,
-    tokenB : TokenInformation,
-    owner  : Address,
+    tokenA: TokenInformation,
+    tokenB: TokenInformation,
+    owner: Address,
     feeRate: Long
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
@@ -40,15 +53,12 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      (feeRate.toDouble / 100D),
+      feeRate.toDouble / 100d,
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
     (poolId, LiquidityPoolCalculatedState(Map(poolId -> liquidityPool)))
   }
-
-  override def sharedResource: Resource[IO, SecurityProvider[IO]] =
-    SecurityProvider.forAsync[IO]
 
   def getFakeSignedUpdate(
     update: LiquidityPoolUpdate
@@ -57,8 +67,16 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       update,
       NonEmptySet.one(
         SignatureProof(
-          Id(Hex("db2faf200159ca3c47924bf5f3bda4f45d681a39f9490053ecf98d788122f7a7973693570bd242e10ab670748e86139847eb682a53c7c5c711b832517ce34860")),
-          Signature(Hex("3045022100fb26702e976a6569caa3507140756fee96b5ba748719abe1b812b17f7279a3dc0220613db28d5c5a30d7353383358b653aa29772151ccf352a2e67a26a74e49eac57"))
+          Id(
+            Hex(
+              "db2faf200159ca3c47924bf5f3bda4f45d681a39f9490053ecf98d788122f7a7973693570bd242e10ab670748e86139847eb682a53c7c5c711b832517ce34860"
+            )
+          ),
+          Signature(
+            Hex(
+              "3045022100fb26702e976a6569caa3507140756fee96b5ba748719abe1b812b17f7279a3dc0220613db28d5c5a30d7353383358b653aa29772151ccf352a2e67a26a74e49eac57"
+            )
+          )
         )
       )
     )
@@ -66,9 +84,11 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
   implicit val eqDataApplicationValidationErrorOr: Eq[DataApplicationValidationErrorOr[Unit]] =
     Eq.fromUniversalEquals
 
-  test("Validate update successfully") { implicit sp =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+  test("Validate update successfully") { implicit res =>
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val liquidityPoolUpdate = LiquidityPoolUpdate(
       primaryToken,
       pairToken,
@@ -78,11 +98,12 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     for {
       validationService <- ValidationService.make[IO]
       response <- validationService.validateUpdate(liquidityPoolUpdate)
-    } yield
-      expect.eql(Valid(()), response)
+    } yield expect.eql(Valid(()), response)
   }
 
-  test("Validate update fail - both tokens none") { implicit sp =>
+  test("Validate update fail - both tokens none") { implicit res =>
+    implicit val (h, sp) = res
+
     val primaryToken = TokenInformation(none, 100L)
     val pairToken = TokenInformation(none, 50L)
     val liquidityPoolUpdate = LiquidityPoolUpdate(
@@ -105,9 +126,11 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     }
   }
 
-  test("Validate data successfully - L0 token - L0 token") { implicit sp =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+  test("Validate data successfully - L0 token - L0 token") { implicit res =>
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val ammOnChainState = AmmOnChainState(List.empty)
     val ammCalculatedState = AmmCalculatedState(Map.empty)
     val state = DataState(ammOnChainState, ammCalculatedState)
@@ -120,13 +143,16 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
     for {
       validationService <- ValidationService.make[IO]
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
-    } yield
-      expect.eql(Valid(()), response)
+    } yield expect.eql(Valid(()), response)
   }
 
-  test("Validate data successfully - L0 token - DAG") { implicit sp =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
+  test("Validate data successfully - L0 token - DAG") { implicit res =>
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
     val pairToken = TokenInformation(none, 50L)
     val ammOnChainState = AmmOnChainState(List.empty)
     val ammCalculatedState = AmmCalculatedState(Map.empty)
@@ -140,12 +166,15 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
     for {
       validationService <- ValidationService.make[IO]
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
-    } yield
-      expect.eql(Valid(()), response)
+    } yield expect.eql(Valid(()), response)
   }
 
-  test("Validate data fail - both tokens none") { implicit sp =>
+  test("Validate data fail - both tokens none") { implicit res =>
+    implicit val (h, sp) = res
+
     val primaryToken = TokenInformation(none, 100L)
     val pairToken = TokenInformation(none, 50L)
     val ammOnChainState = AmmOnChainState(List.empty)
@@ -160,6 +189,8 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
     for {
       validationService <- ValidationService.make[IO]
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
     } yield {
       val expectedError = response match {
@@ -171,9 +202,11 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       expect(expectedError)
     }
   }
-  test("Validate data fail - pool already exists") { implicit sp =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+  test("Validate data fail - pool already exists") { implicit res =>
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
 
     val (_, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress, 0)
@@ -192,6 +225,8 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
     for {
       validationService <- ValidationService.make[IO]
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
     } yield {
       val expectedError = response match {

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -5,30 +5,41 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, NonEmptySet}
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
+import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.PosLong
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.ID.Id
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.hex.Hex
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.signature.{Signature, SignatureProof}
+import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvider}
 import org.amm_metagraph.shared_data.Utils.{DoubleOps, LongOps, PosLongOps}
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, LiquidityProviders, TokenInformation}
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress
-import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, AmmOnChainState, LiquidityPoolCalculatedState, OperationType, StakingCalculatedState}
-import org.amm_metagraph.shared_data.validations.ValidationService
-import org.amm_metagraph.shared_data.validations.Errors
-import org.tessellation.currency.dataApplication.DataState
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.schema.ID.Id
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.schema.address.Address
-import org.tessellation.security.SecurityProvider
-import org.tessellation.security.hex.Hex
-import org.tessellation.security.signature.Signed
-import org.tessellation.security.signature.signature.{Signature, SignatureProof}
+import org.amm_metagraph.shared_data.types.States._
+import org.amm_metagraph.shared_data.validations.{Errors, ValidationService}
 import weaver.MutableIOSuite
 
-object StakingValidationTest extends MutableIOSuite {
-  type Res = SecurityProvider[IO]
+import scala.collection.immutable.{SortedMap, SortedSet}
 
-  override def sharedResource: Resource[IO, SecurityProvider[IO]] =
-    SecurityProvider.forAsync[IO]
+object StakingValidationTest extends MutableIOSuite {
+  type Res = (Hasher[IO], SecurityProvider[IO])
+
+  override def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h = Hasher.forJson[IO]
+  } yield (h, sp)
 
   def buildLiquidityPoolCalculatedState(
     tokenA : TokenInformation,
@@ -45,7 +56,7 @@ object StakingValidationTest extends MutableIOSuite {
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      (feeRate.toDouble / 100D),
+      feeRate.toDouble / 100d,
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
@@ -59,8 +70,16 @@ object StakingValidationTest extends MutableIOSuite {
       update,
       NonEmptySet.one(
         SignatureProof(
-          Id(Hex("db2faf200159ca3c47924bf5f3bda4f45d681a39f9490053ecf98d788122f7a7973693570bd242e10ab670748e86139847eb682a53c7c5c711b832517ce34860")),
-          Signature(Hex("3045022100fb26702e976a6569caa3507140756fee96b5ba748719abe1b812b17f7279a3dc0220613db28d5c5a30d7353383358b653aa29772151ccf352a2e67a26a74e49eac57"))
+          Id(
+            Hex(
+              "db2faf200159ca3c47924bf5f3bda4f45d681a39f9490053ecf98d788122f7a7973693570bd242e10ab670748e86139847eb682a53c7c5c711b832517ce34860"
+            )
+          ),
+          Signature(
+            Hex(
+              "3045022100fb26702e976a6569caa3507140756fee96b5ba748719abe1b812b17f7279a3dc0220613db28d5c5a30d7353383358b653aa29772151ccf352a2e67a26a74e49eac57"
+            )
+          )
         )
       )
     )
@@ -69,12 +88,14 @@ object StakingValidationTest extends MutableIOSuite {
     Eq.fromUniversalEquals
 
   test("Validate update successfully") { implicit res =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
 
     val stakingUpdate = StakingUpdate(
-      "fake-primary-txn-1",
-      "fake-pair-txn-1",
+      Hash.empty,
+      Hash.empty,
       primaryToken.identifier,
       100L.toPosLongUnsafe,
       pairToken.identifier
@@ -82,13 +103,14 @@ object StakingValidationTest extends MutableIOSuite {
     for {
       validationService <- ValidationService.make[IO]
       response <- validationService.validateUpdate(stakingUpdate)
-    } yield
-      expect.eql(Valid(()), response)
+    } yield expect.eql(Valid(()), response)
   }
 
   test("Validate data successfully") { implicit res =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
 
     val (_, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress, 0)
@@ -97,33 +119,70 @@ object StakingValidationTest extends MutableIOSuite {
       Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
     )
     val state = DataState(ammOnChainState, ammCalculatedState)
-    val stakingUpdate = StakingUpdate(
-      "fake-primary-txn-1",
-      "fake-pair-txn-1",
-      primaryToken.identifier,
-      100L.toPosLongUnsafe,
-      pairToken.identifier
-    )
 
-    val fakeSignedUpdate = getFakeSignedUpdate(stakingUpdate)
     for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      allowSpendTokenA = AllowSpend(
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc"),
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb"),
+        none,
+        SwapAmount(PosLong.MinValue),
+        AllowSpendFee(PosLong.MinValue),
+        AllowSpendReference(AllowSpendOrdinal.first, Hash.empty),
+        EpochProgress.MaxValue,
+        List.empty
+      )
+      allowSpendTokenB = AllowSpend(
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc"),
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb"),
+        none,
+        SwapAmount(PosLong.MaxValue),
+        AllowSpendFee(PosLong.MinValue),
+        AllowSpendReference(AllowSpendOrdinal.first, Hash.empty),
+        EpochProgress.MaxValue,
+        List.empty
+      )
+
+      signedAllowSpendA <- Signed
+        .forAsyncHasher[IO, AllowSpend](allowSpendTokenA, keyPair)
+        .flatMap(_.toHashed[IO])
+      signedAllowSpendB <- Signed
+        .forAsyncHasher[IO, AllowSpend](allowSpendTokenB, keyPair)
+        .flatMap(_.toHashed[IO])
+
+      stakingUpdate = StakingUpdate(
+        signedAllowSpendA.hash,
+        signedAllowSpendB.hash,
+        primaryToken.identifier,
+        100L.toPosLongUnsafe,
+        pairToken.identifier
+      )
+
+      fakeSignedUpdate = getFakeSignedUpdate(stakingUpdate)
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
+        keyPair,
+        SortedMap(
+          Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc") -> SortedSet(signedAllowSpendA.signed, signedAllowSpendB.signed)
+        )
+      )
       validationService <- ValidationService.make[IO]
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
-    } yield
-      expect.eql(Valid(()), response)
+    } yield expect.eql(Valid(()), response)
   }
 
   test("Validate data fails - Liquidity pool does not exist") { implicit res =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+    implicit val (h, sp) = res
+
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
 
     val ammOnChainState = AmmOnChainState(List.empty) // No pools initialized
     val ammCalculatedState = AmmCalculatedState(Map.empty)
     val state = DataState(ammOnChainState, ammCalculatedState)
 
     val stakingUpdate = StakingUpdate(
-      "fake-primary-txn-1",
-      "fake-pair-txn-1",
+      Hash.empty,
+      Hash.empty,
       primaryToken.identifier,
       100L.toPosLongUnsafe,
       pairToken.identifier
@@ -133,6 +192,8 @@ object StakingValidationTest extends MutableIOSuite {
 
     for {
       validationService <- ValidationService.make[IO]
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
     } yield {
       val expectedError = response match {
@@ -146,8 +207,9 @@ object StakingValidationTest extends MutableIOSuite {
   }
 
   test("Validate data fails - Txn already exists") { implicit res =>
-    val primaryToken = TokenInformation(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some, 100L)
-    val pairToken = TokenInformation(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5").some, 50L)
+    implicit val (h, sp) = res
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
     val signerAddress = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
 
@@ -156,20 +218,24 @@ object StakingValidationTest extends MutableIOSuite {
     val ammCalculatedState = AmmCalculatedState(
       Map(
         OperationType.LiquidityPool -> liquidityPoolCalculatedState,
-        OperationType.Staking -> StakingCalculatedState(Map(signerAddress -> StakingCalculatedStateAddress(
-          "fake-primary-txn-1",
-          "fake-pair-txn-1",
-          primaryToken,
-          pairToken,
-          SnapshotOrdinal.MinValue,
-          none
-        )))
+        OperationType.Staking -> StakingCalculatedState(
+          Map(
+            signerAddress -> StakingCalculatedStateAddress(
+              Hash.empty,
+              Hash.empty,
+              primaryToken,
+              pairToken,
+              SnapshotOrdinal.MinValue,
+              none
+            )
+          )
+        )
       )
     )
     val state = DataState(ammOnChainState, ammCalculatedState)
     val stakingUpdate = StakingUpdate(
-      "fake-primary-txn-1",
-      "fake-pair-txn-1",
+      Hash.empty,
+      Hash.empty,
       primaryToken.identifier,
       100L.toPosLongUnsafe,
       pairToken.identifier
@@ -178,6 +244,8 @@ object StakingValidationTest extends MutableIOSuite {
     val fakeSignedUpdate = getFakeSignedUpdate(stakingUpdate)
     for {
       validationService <- ValidationService.make[IO]
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(keyPair, SortedMap.empty)
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
     } yield {
       val expectedError = response match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,12 @@ import sbt.*
 object Dependencies {
 
   object V {
-    val tessellation = "2.8.1"
+    val tessellation = "99.99.99"
     val decline = "2.4.1"
+    val organizeImports = "0.5.0"
   }
 
-  def tessellation(artifact: String): ModuleID = "org.constellation" %% s"tessellation-$artifact" % V.tessellation
+  def tessellation(artifact: String): ModuleID = "io.constellationnetwork" %% s"tessellation-$artifact" % V.tessellation
 
   def decline(artifact: String = ""): ModuleID =
     "com.monovore" %% {
@@ -27,11 +28,8 @@ object Dependencies {
     val weaverCats = "com.disneystreaming" %% "weaver-cats" % "0.8.1"
     val weaverDiscipline = "com.disneystreaming" %% "weaver-discipline" % "0.8.1"
     val weaverScalaCheck = "com.disneystreaming" %% "weaver-scalacheck" % "0.8.1"
+    val organizeImports = "com.github.liancheng" %% "organize-imports" % V.organizeImports
   }
-
-
-  // Scalafix rules
-  val organizeImports = "com.github.liancheng" %% "organize-imports" % "0.5.0"
 
   object CompilerPlugin {
 


### PR DESCRIPTION
### Changes
+ Added validations for Staking operations.
+ Integrated Scalafix and Scalafmt into the project.
+ Updated existing tests to align with new validations.
+ Refactored SpendTransactions as an output of the Staking process.

### Notes
+ This is an initial version; further improvements are planned.
+ Additional tests are needed to ensure full coverage.
+ This PR is based on the branch containing lastSyncGlobalSnapshot.
+ Current validations may be adjusted, and additional validations may be introduced in future updates.