### PR TITLE
feat: adding spend transaction to swap operation and validating allow spends in swap

### DIFF
--- a/modules/data_l1/src/main/scala/org/amm_metagraph/data_l1/DataL1Service.scala
+++ b/modules/data_l1/src/main/scala/org/amm_metagraph/data_l1/DataL1Service.scala
@@ -34,7 +34,7 @@ object DataL1Service {
     )
   }
 
-  private def makeBaseDataApplicationL1Service[F[+_]: Async: JsonSerializer: Hasher](
+  private def makeBaseDataApplicationL1Service[F[+_]: Async: JsonSerializer](
     calculatedStateService: CalculatedStateService[F],
     validationService: ValidationService[F]
   ): BaseDataApplicationL1Service[F] = BaseDataApplicationL1Service(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/SpendTransactions.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/SpendTransactions.scala
@@ -1,0 +1,37 @@
+package org.amm_metagraph.shared_data
+
+import scala.collection.immutable.SortedSet
+
+import io.constellationnetwork.schema.artifact._
+
+import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
+
+object SpendTransactions {
+  def getCalculatedStateSpendTransactions(
+    calculatedState: AmmCalculatedState
+  ): (SortedSet[PendingSpendTransaction], SortedSet[ConcludedSpendTransaction]) =
+    getSpendTransactions(calculatedState.spendTransactions)
+
+  def getCombinedSpendTransactions(
+    artifacts: SortedSet[SharedArtifact]
+  ): (SortedSet[PendingSpendTransaction], SortedSet[ConcludedSpendTransaction]) = {
+    val spendTransactions = artifacts.collect {
+      case transaction: SpendTransaction => transaction
+    }
+    getSpendTransactions(spendTransactions)
+  }
+
+  private def getSpendTransactions(
+    spendTransactions: SortedSet[SpendTransaction]
+  ): (SortedSet[PendingSpendTransaction], SortedSet[ConcludedSpendTransaction]) = {
+    val (pending, concluded) = spendTransactions.partition {
+      case _: PendingSpendTransaction   => true
+      case _: ConcludedSpendTransaction => false
+    }
+
+    (
+      pending.collect { case t: PendingSpendTransaction => t },
+      concluded.collect { case t: ConcludedSpendTransaction => t }
+    )
+  }
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
@@ -1,5 +1,7 @@
 package org.amm_metagraph.shared_data.calculated_state
 
+import scala.collection.immutable.SortedSet
+
 import io.constellationnetwork.schema.SnapshotOrdinal
 
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
@@ -8,5 +10,5 @@ case class CalculatedState(ordinal: SnapshotOrdinal, state: AmmCalculatedState)
 
 object CalculatedState {
   def empty: CalculatedState =
-    CalculatedState(SnapshotOrdinal.MinValue, AmmCalculatedState(Map.empty))
+    CalculatedState(SnapshotOrdinal.MinValue, AmmCalculatedState(Map.empty, SortedSet.empty))
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
@@ -37,12 +37,14 @@ object CalculatedStateService {
         ): F[Boolean] =
           stateRef.modify { currentState =>
             val currentCalculatedState = currentState.state
-            val updatedDevices = state.ammState.foldLeft(currentCalculatedState.ammState) {
+            val updatedOperations = state.operations.foldLeft(currentCalculatedState.operations) {
               case (acc, (address, value)) =>
                 acc.updated(address, value)
             }
 
-            (CalculatedState(snapshotOrdinal, AmmCalculatedState(updatedDevices)), true)
+            val updatedSpendTransactions = currentCalculatedState.spendTransactions ++ state.spendTransactions
+
+            (CalculatedState(snapshotOrdinal, AmmCalculatedState(updatedOperations, updatedSpendTransactions)), true)
           }
 
         override def hash(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
@@ -17,7 +17,7 @@ object LiquidityPoolCombiner {
     liquidityPoolUpdate: LiquidityPoolUpdate,
     signerAddress: Address
   ): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
-    val liquidityPools = getLiquidityPools(acc)
+    val liquidityPools = getLiquidityPools(acc.calculated)
 
     for {
       poolId <- buildLiquidityPoolUniqueIdentifier(liquidityPoolUpdate.tokenA.identifier, liquidityPoolUpdate.tokenB.identifier)
@@ -41,8 +41,8 @@ object LiquidityPoolCombiner {
         poolTotalLiquidity,
         LiquidityProviders(Map(signerAddress -> poolTotalLiquidity))
       )
-      updatedLiquidityPoolCalculatedState = LiquidityPoolCalculatedState(liquidityPools.updated(poolId, liquidityPool))
-      updatedState = acc.calculated.ammState.updated(OperationType.LiquidityPool, updatedLiquidityPoolCalculatedState)
+      updatedLiquidityPoolCalculatedState = LiquidityPoolCalculatedState(liquidityPools.updated(poolId.value, liquidityPool))
+      updatedState = acc.calculated.operations.updated(OperationType.LiquidityPool, updatedLiquidityPoolCalculatedState)
       updates: List[AmmUpdate] = liquidityPoolUpdate :: acc.onChain.updates
     } yield
       DataState(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/SwapCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/SwapCombiner.scala
@@ -3,12 +3,17 @@ package org.amm_metagraph.shared_data.combiners
 import cats.effect.Async
 import cats.syntax.all._
 
-import io.constellationnetwork.currency.dataApplication.DataState
+import scala.collection.immutable.SortedSet
+
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.SharedArtifact
+import io.constellationnetwork.schema.swap.AllowSpend
+import io.constellationnetwork.security.{Hashed, Hasher}
 
 import org.amm_metagraph.shared_data.Utils._
-import org.amm_metagraph.shared_data.types.DataUpdates.{AmmUpdate, SwapUpdate}
+import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, TokenInformation, getLiquidityPools}
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.Swap.{SwapCalculatedStateAddress, SwapCalculatedStateLastReference}
@@ -18,10 +23,10 @@ object SwapCombiner {
     swapUpdate: SwapUpdate,
     liquidityPool: LiquidityPool
   ): (TokenInformation, TokenInformation) = {
-    val fromTokenInfo = if (swapUpdate.swapFromToken == liquidityPool.tokenA.identifier) liquidityPool.tokenA else liquidityPool.tokenB
-    val toTokenInfo = if (swapUpdate.swapToToken == liquidityPool.tokenA.identifier) liquidityPool.tokenA else liquidityPool.tokenB
+    val fromTokenInfo = if (swapUpdate.swapFromPair == liquidityPool.tokenA.identifier) liquidityPool.tokenA else liquidityPool.tokenB
+    val toTokenInfo = if (swapUpdate.swapToPair == liquidityPool.tokenA.identifier) liquidityPool.tokenA else liquidityPool.tokenB
 
-    val swapAmount = swapUpdate.maxAmount.value
+    val swapAmount = swapUpdate.maxAmount.value.value
     val fee = swapAmount * liquidityPool.feeRate
     val netSwapAmount = swapAmount - fee
 
@@ -49,19 +54,19 @@ object SwapCombiner {
     )
   }
 
-  def combineSwap[F[_]: Async](
+  def combineSwap[F[_]: Async: Hasher](
     acc: DataState[AmmOnChainState, AmmCalculatedState],
     swapUpdate: SwapUpdate,
     signerAddress: Address,
     currentSnapshotOrdinal: SnapshotOrdinal
-  ): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
+  )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
     val swapCalculatedStateAddresses =
-      acc.calculated.ammState.get(OperationType.Swap).fold(Map.empty[Address, SwapCalculatedStateAddress]) {
+      acc.calculated.operations.get(OperationType.Swap).fold(Map.empty[Address, SwapCalculatedStateAddress]) {
         case swapCalculatedState: SwapCalculatedState => swapCalculatedState.addresses
         case _                                        => Map.empty
       }
 
-    val liquidityPoolsCalculatedState = getLiquidityPools(acc)
+    val liquidityPoolsCalculatedState = getLiquidityPools(acc.calculated)
 
     val maybeLastSwapInfo = swapCalculatedStateAddresses.get(signerAddress) match {
       case Some(swapCalculatedState: SwapCalculatedStateAddress) =>
@@ -73,7 +78,7 @@ object SwapCombiner {
           swapCalculatedState.allowSpendReference,
           swapCalculatedState.minAmount,
           swapCalculatedState.maxAmount,
-          swapCalculatedState.maxValidGsOrdinal,
+          swapCalculatedState.maxValidGsEpochProgress,
           swapCalculatedState.poolId,
           swapCalculatedState.minPrice,
           swapCalculatedState.maxPrice,
@@ -84,7 +89,7 @@ object SwapCombiner {
     }
 
     for {
-      poolId <- buildLiquidityPoolUniqueIdentifier(swapUpdate.swapFromToken, swapUpdate.swapToToken)
+      poolId <- buildLiquidityPoolUniqueIdentifier(swapUpdate.swapFromPair, swapUpdate.swapToPair)
       liquidityPool <- getLiquidityPoolByPoolId(liquidityPoolsCalculatedState, poolId)
       (fromTokenInfo, toTokenInfo) = getUpdatedTokenInformation(swapUpdate, liquidityPool)
       liquidityPoolUpdated = updateLiquidityPool(liquidityPool, fromTokenInfo, toTokenInfo)
@@ -97,7 +102,7 @@ object SwapCombiner {
         swapUpdate.allowSpendReference,
         swapUpdate.minAmount,
         swapUpdate.maxAmount,
-        swapUpdate.maxValidGsOrdinal,
+        swapUpdate.maxValidGsEpochProgress,
         swapUpdate.poolId,
         swapUpdate.minPrice,
         swapUpdate.maxPrice,
@@ -105,17 +110,28 @@ object SwapCombiner {
         maybeLastSwapInfo
       )
       updatedSwapCalculatedState = SwapCalculatedState(swapCalculatedStateAddresses.updated(signerAddress, swapCalculatedStateAddress))
-      updatedLiquidityPool = LiquidityPoolCalculatedState(liquidityPoolsCalculatedState.updated(poolId, liquidityPoolUpdated))
+      updatedLiquidityPool = LiquidityPoolCalculatedState(liquidityPoolsCalculatedState.updated(poolId.value, liquidityPoolUpdated))
 
       updates: List[AmmUpdate] = swapUpdate :: acc.onChain.updates
-      updatedCalculatedState = acc.calculated.ammState
+      updatedCalculatedState = acc.calculated.operations
         .updated(OperationType.Swap, updatedSwapCalculatedState)
         .updated(OperationType.LiquidityPool, updatedLiquidityPool)
+
+      allowSpend <- getAllowSpendLastSyncGlobalSnapshotState(
+        swapUpdate.allowSpendReference
+      ).flatMap {
+        _.fold(
+          Async[F].raiseError[Hashed[AllowSpend]](new IllegalStateException("Allow spend does not exists"))
+        )(Async[F].pure)
+      }
+
+      spendTransaction: SharedArtifact = generatePendingSpendTransaction(allowSpend)
 
     } yield
       DataState(
         AmmOnChainState(updates),
-        AmmCalculatedState(updatedCalculatedState)
+        AmmCalculatedState(updatedCalculatedState),
+        SortedSet(spendTransaction)
       )
   }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawCombiner.scala
@@ -14,7 +14,7 @@ object WithdrawCombiner {
     signerAddress: Address
   ): DataState[AmmOnChainState, AmmCalculatedState] = {
     val withdrawCalculatedStateAddresses =
-      acc.calculated.ammState.get(OperationType.Withdraw).fold(Map.empty[Address, WithdrawCalculatedStateAddress]) {
+      acc.calculated.operations.get(OperationType.Withdraw).fold(Map.empty[Address, WithdrawCalculatedStateAddress]) {
         case stakingCalculatedState: WithdrawCalculatedState => stakingCalculatedState.addresses
         case _                                               => Map.empty
       }
@@ -25,7 +25,7 @@ object WithdrawCombiner {
     val updatedWithdrawCalculatedState = WithdrawCalculatedState(
       withdrawCalculatedStateAddresses.updated(signerAddress, withdrawCalculatedStateAddress)
     )
-    val updatedState = acc.calculated.ammState.updated(OperationType.Withdraw, updatedWithdrawCalculatedState)
+    val updatedState = acc.calculated.operations.updated(OperationType.Withdraw, updatedWithdrawCalculatedState)
     val updates: List[AmmUpdate] = withdrawUpdate :: acc.onChain.updates
 
     DataState(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
@@ -1,15 +1,16 @@
 package org.amm_metagraph.shared_data.types
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate
-import io.constellationnetwork.schema.SnapshotOrdinal
-import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap.{CurrencyId, SwapAmount}
 import io.constellationnetwork.security.hash.Hash
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
 import io.circe.refined._
-import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 
 object DataUpdates {
   @derive(encoder, decoder)
@@ -33,18 +34,18 @@ object DataUpdates {
 
   @derive(decoder, encoder)
   case class SwapUpdate(
-    swapFromToken: Option[CurrencyId],
-    swapToToken: Option[CurrencyId],
-    metagraphAddress: CurrencyId,
-    fee: Long,
+    sourceAddress: Address,
+    swapFromPair: Option[CurrencyId],
+    swapToPair: Option[CurrencyId],
+    fee: NonNegLong,
     reference: String,
-    allowSpendReference: String,
-    minAmount: PosLong,
-    maxAmount: PosLong,
-    maxValidGsOrdinal: SnapshotOrdinal,
-    poolId: Option[String],
-    minPrice: PosLong,
-    maxPrice: PosLong
+    allowSpendReference: Hash,
+    minAmount: SwapAmount,
+    maxAmount: SwapAmount,
+    maxValidGsEpochProgress: EpochProgress,
+    poolId: Option[PoolId],
+    minPrice: Option[PosLong],
+    maxPrice: Option[PosLong]
   ) extends AmmUpdate
 
   @derive(decoder, encoder)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
@@ -1,8 +1,5 @@
 package org.amm_metagraph.shared_data.types
 
-import cats.effect.Async
-
-import io.constellationnetwork.currency.dataApplication.DataState
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.swap.CurrencyId
 
@@ -10,9 +7,14 @@ import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.refined._
+import io.estatico.newtype.macros.newtype
 import org.amm_metagraph.shared_data.types.States._
 
 object LiquidityPool {
+  @derive(encoder, decoder)
+  @newtype
+  case class PoolId(value: String)
+
   @derive(encoder, decoder)
   case class TokenInformation(
     identifier: Option[CurrencyId],
@@ -26,7 +28,7 @@ object LiquidityPool {
 
   @derive(encoder, decoder)
   case class LiquidityPool(
-    poolId: String,
+    poolId: PoolId,
     tokenA: TokenInformation,
     tokenB: TokenInformation,
     owner: Address,
@@ -36,8 +38,8 @@ object LiquidityPool {
     liquidityProviders: LiquidityProviders
   )
 
-  def getLiquidityPools[F[_]: Async](state: DataState[AmmOnChainState, AmmCalculatedState]): Map[String, LiquidityPool] =
-    state.calculated.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
+  def getLiquidityPools(state: AmmCalculatedState): Map[String, LiquidityPool] =
+    state.operations.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
       case liquidityPoolsCalculatedState: LiquidityPoolCalculatedState => liquidityPoolsCalculatedState.liquidityPools
       case _                                                           => Map.empty
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
@@ -1,7 +1,10 @@
 package org.amm_metagraph.shared_data.types
 
+import scala.collection.immutable.SortedSet
+
 import io.constellationnetwork.currency.dataApplication.{DataCalculatedState, DataOnChainState}
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.artifact.SpendTransaction
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
@@ -58,7 +61,8 @@ object States {
 
   @derive(encoder, decoder)
   case class AmmCalculatedState(
-    ammState: Map[OperationType, AmmOffChainState]
+    operations: Map[OperationType, AmmOffChainState],
+    spendTransactions: SortedSet[SpendTransaction] = SortedSet.empty[SpendTransaction]
   ) extends DataCalculatedState
 
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
@@ -1,12 +1,15 @@
 package org.amm_metagraph.shared_data.types
 
 import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap.SwapAmount
+import io.constellationnetwork.security.hash.Hash
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
 import io.circe.refined._
-import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 
 object Swap {
 
@@ -14,15 +17,15 @@ object Swap {
   case class SwapCalculatedStateLastReference(
     fromToken: TokenInformation,
     toToken: TokenInformation,
-    fee: Long,
+    fee: NonNegLong,
     reference: String,
-    allowSpendReference: String,
-    minAmount: PosLong,
-    maxAmount: PosLong,
-    maxValidGsOrdinal: SnapshotOrdinal,
-    poolId: Option[String],
-    minPrice: PosLong,
-    maxPrice: PosLong,
+    allowSpendReference: Hash,
+    minAmount: SwapAmount,
+    maxAmount: SwapAmount,
+    maxValidGsEpochProgress: EpochProgress,
+    poolId: Option[PoolId],
+    minPrice: Option[PosLong],
+    maxPrice: Option[PosLong],
     ordinal: SnapshotOrdinal
   )
 
@@ -30,15 +33,15 @@ object Swap {
   case class SwapCalculatedStateAddress(
     fromToken: TokenInformation,
     toToken: TokenInformation,
-    fee: Long,
+    fee: NonNegLong,
     reference: String,
-    allowSpendReference: String,
-    minAmount: PosLong,
-    maxAmount: PosLong,
-    maxValidGsOrdinal: SnapshotOrdinal,
-    poolId: Option[String],
-    minPrice: PosLong,
-    maxPrice: PosLong,
+    allowSpendReference: Hash,
+    minAmount: SwapAmount,
+    maxAmount: SwapAmount,
+    maxValidGsEpochProgress: EpochProgress,
+    poolId: Option[PoolId],
+    minPrice: Option[PosLong],
+    maxPrice: Option[PosLong],
     ordinal: SnapshotOrdinal,
     lastSwapUpdate: Option[SwapCalculatedStateLastReference]
   )

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -46,14 +46,6 @@ object Errors {
     val message = "Different allow spend destination"
   }
 
-  case object StakingInvalidTokenPair extends DataApplicationValidationError {
-    val message = "Staking invalid token"
-  }
-
-  case object StakingProductVariant extends DataApplicationValidationError {
-    val message = "Staking product should be invariant"
-  }
-
   case object LiquidityPoolNotEnoughInformation extends DataApplicationValidationError {
     val message = "You should provide at 2 tokens, or at least 1 token to use DAG as the second one"
   }
@@ -72,5 +64,17 @@ object Errors {
 
   case object SwapLiquidityPoolNotEnoughTokens extends DataApplicationValidationError {
     val message = "Swap liquidity pool not enough tokens"
+  }
+
+  case object SwapMissingAllowSpend extends DataApplicationValidationError {
+    val message = "Missing swap allow spend"
+  }
+
+  case object SwapAllowSpendDifferentCurrency extends DataApplicationValidationError {
+    val message = "Different currency between swap update and allow spend"
+  }
+
+  case object SwapAllowSpendDifferentSourceAddress extends DataApplicationValidationError {
+    val message = "Different source address between swap update and allow spend"
   }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
@@ -7,8 +7,8 @@ import io.constellationnetwork.currency.dataApplication.dataApplication.DataAppl
 
 import org.amm_metagraph.shared_data.Utils.buildLiquidityPoolUniqueIdentifier
 import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
-import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
-import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, LiquidityPoolCalculatedState, OperationType}
+import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, getLiquidityPools}
+import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 import org.amm_metagraph.shared_data.validations.Errors.{LiquidityPoolAlreadyExists, LiquidityPoolNotEnoughInformation}
 
 object LiquidityPoolValidations {
@@ -24,10 +24,7 @@ object LiquidityPoolValidations {
   ): F[DataApplicationValidationErrorOr[Unit]] =
     for {
       liquidityPoolValidationsL1 <- liquidityPoolValidationsL1(liquidityPoolUpdate)
-      calculatedState = state.ammState.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
-        case liquidityPoolCalculatedState: LiquidityPoolCalculatedState => liquidityPoolCalculatedState.liquidityPools
-        case _                                                          => Map.empty[String, LiquidityPool]
-      }
+      calculatedState = getLiquidityPools(state)
       poolAlreadyExists <- validateIfPoolAlreadyExists(
         liquidityPoolUpdate,
         calculatedState
@@ -45,5 +42,5 @@ object LiquidityPoolValidations {
   ): F[DataApplicationValidationErrorOr[Unit]] =
     for {
       poolId <- buildLiquidityPoolUniqueIdentifier(liquidityPoolUpdate.tokenA.identifier, liquidityPoolUpdate.tokenB.identifier)
-    } yield LiquidityPoolAlreadyExists.whenA(currentLiquidityPools.contains(poolId))
+    } yield LiquidityPoolAlreadyExists.whenA(currentLiquidityPools.contains(poolId.value))
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -38,9 +38,9 @@ object LiquidityPoolCombinerTest extends SimpleIOSuite {
       )
       poolId <- buildLiquidityPoolUniqueIdentifier(primaryToken.identifier, pairToken.identifier)
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .ammState(OperationType.LiquidityPool)
+        .operations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
-      updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
+      updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId.value)
     } yield
       expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
         expect.eql(primaryToken.identifier.get, updatedLiquidityPool.tokenA.identifier.get) &&
@@ -70,9 +70,9 @@ object LiquidityPoolCombinerTest extends SimpleIOSuite {
       )
       poolId <- buildLiquidityPoolUniqueIdentifier(primaryToken.identifier, pairToken.identifier)
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .ammState(OperationType.LiquidityPool)
+        .operations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
-      updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
+      updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId.value)
     } yield
       expect.eql(100L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
         expect.eql(primaryToken.identifier.get, updatedLiquidityPool.tokenA.identifier.get) &&

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
@@ -22,7 +22,7 @@ import eu.timepit.refined.types.all.PosLong
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.combiners.StakingCombiner.combineStaking
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, LiquidityProviders, TokenInformation}
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
 import weaver.MutableIOSuite
 
@@ -43,7 +43,7 @@ object StakingCombinerTest extends MutableIOSuite {
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
     val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
-    val poolId = s"$primaryAddressAsString-$pairAddressAsString"
+    val poolId = org.amm_metagraph.shared_data.types.LiquidityPool.PoolId(s"$primaryAddressAsString-$pairAddressAsString")
     val liquidityPool = LiquidityPool(
       poolId,
       tokenA.copy(amount = tokenA.amount.value.toTokenAmountFormat.toPosLongUnsafe),
@@ -54,7 +54,7 @@ object StakingCombinerTest extends MutableIOSuite {
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
-    (poolId, LiquidityPoolCalculatedState(Map(poolId -> liquidityPool)))
+    (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }
 
   test("Test combining successfully when liquidity pool exists") { implicit res =>
@@ -121,14 +121,14 @@ object StakingCombinerTest extends MutableIOSuite {
         SnapshotOrdinal.MinValue
       )
 
-      stakingCalculatedState = stakeResponse.calculated.ammState(OperationType.Staking).asInstanceOf[StakingCalculatedState]
+      stakingCalculatedState = stakeResponse.calculated.operations(OperationType.Staking).asInstanceOf[StakingCalculatedState]
       addressStakedResponse = stakingCalculatedState.addresses(ownerAddress)
 
-      oldLiquidityPoolCalculatedState = state.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      oldLiquidityPoolCalculatedState = state.calculated.operations(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
       oldLiquidityPool = oldLiquidityPoolCalculatedState.liquidityPools(poolId)
 
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .ammState(OperationType.LiquidityPool)
+        .operations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
 

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -1,22 +1,40 @@
 package com.my.dor_metagraph.shared_data.combiners
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.syntax.all._
 
-import io.constellationnetwork.currency.dataApplication.DataState
-import io.constellationnetwork.schema.SnapshotOrdinal
-import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.swap.CurrencyId
+import scala.collection.immutable.{SortedMap, SortedSet}
 
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap._
+import io.constellationnetwork.schema.{SnapshotOrdinal, artifact}
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvider}
+
+import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.PosLong
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.combiners.SwapCombiner.combineSwap
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
-import weaver.SimpleIOSuite
+import weaver.MutableIOSuite
 
-object SwapCombinerTest extends SimpleIOSuite {
+object SwapCombinerTest extends MutableIOSuite {
+  type Res = (Hasher[IO], SecurityProvider[IO])
+
+  override def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h = Hasher.forJson[IO]
+  } yield (h, sp)
+
   def buildLiquidityPoolCalculatedState(
     tokenA: TokenInformation,
     tokenB: TokenInformation,
@@ -25,7 +43,7 @@ object SwapCombinerTest extends SimpleIOSuite {
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
     val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
-    val poolId = s"$primaryAddressAsString-$pairAddressAsString"
+    val poolId = org.amm_metagraph.shared_data.types.LiquidityPool.PoolId(s"$primaryAddressAsString-$pairAddressAsString")
     val liquidityPool = LiquidityPool(
       poolId,
       tokenA,
@@ -36,16 +54,17 @@ object SwapCombinerTest extends SimpleIOSuite {
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
-    (poolId, LiquidityPoolCalculatedState(Map(poolId -> liquidityPool)))
+    (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }
 
-  test("Test swap successfully when liquidity pool exists 3% fee") {
+  test("Test swap successfully when liquidity pool exists 3% fee") { implicit res =>
+    implicit val (h, sp) = res
+
     val primaryToken =
       TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
     val pairToken =
       TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 2000000L.toTokenAmountFormat.toPosLongUnsafe)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
-    val metagraphAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Gs")
 
     val (poolId, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress, 3L)
     val ammOnChainState = AmmOnChainState(List.empty)
@@ -53,39 +72,70 @@ object SwapCombinerTest extends SimpleIOSuite {
       Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
     )
     val state = DataState(ammOnChainState, ammCalculatedState)
-    val stakingUpdate = SwapUpdate(
-      primaryToken.identifier,
-      pairToken.identifier,
-      CurrencyId(metagraphAddress),
-      0L,
-      "",
-      "",
-      100000L.toPosLongUnsafe,
-      100000L.toPosLongUnsafe,
-      SnapshotOrdinal.unsafeApply(20),
-      none,
-      1L.toPosLongUnsafe,
-      20000.toPosLongUnsafe
-    )
-
     for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      allowSpend = AllowSpend(
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc"),
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb"),
+        Some(CurrencyId(ownerAddress)),
+        SwapAmount(PosLong.MinValue),
+        AllowSpendFee(PosLong.MinValue),
+        AllowSpendReference(AllowSpendOrdinal.first, Hash.empty),
+        EpochProgress.MaxValue,
+        List.empty
+      )
+
+      signedAllowSpend <- Signed
+        .forAsyncHasher[IO, AllowSpend](allowSpend, keyPair)
+        .flatMap(_.toHashed[IO])
+
+      swapUpdate = SwapUpdate(
+        ownerAddress,
+        primaryToken.identifier,
+        pairToken.identifier,
+        0L,
+        "",
+        signedAllowSpend.hash,
+        SwapAmount(100000L),
+        SwapAmount(100000L),
+        EpochProgress.MaxValue,
+        none,
+        none,
+        none
+      )
+
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
+        keyPair,
+        SortedMap(
+          ownerAddress -> SortedSet(signedAllowSpend.signed)
+        )
+      )
+
       stakeResponse <- combineSwap[IO](
         state,
-        stakingUpdate,
+        swapUpdate,
         ownerAddress,
         SnapshotOrdinal.MinValue
       )
 
-      swapCalculatedState = stakeResponse.calculated.ammState(OperationType.Swap).asInstanceOf[SwapCalculatedState]
+      swapCalculatedState = stakeResponse.calculated.operations(OperationType.Swap).asInstanceOf[SwapCalculatedState]
       addressSwapResponse = swapCalculatedState.addresses(ownerAddress)
 
-      oldLiquidityPoolCalculatedState = state.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      oldLiquidityPoolCalculatedState = state.calculated.operations(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
       oldLiquidityPool = oldLiquidityPoolCalculatedState.liquidityPools(poolId)
 
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .ammState(OperationType.LiquidityPool)
+        .operations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
+
+      swapSpendTransactions = stakeResponse.sharedArtifacts.collect {
+        case transaction: artifact.SpendTransaction => transaction
+      }.collect {
+        case transaction: artifact.PendingSpendTransaction => transaction
+      }
+
+      spendTransaction = swapSpendTransactions.find(_.allowSpendRef === signedAllowSpend.hash)
     } yield
       expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
         expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
@@ -93,16 +143,18 @@ object SwapCombinerTest extends SimpleIOSuite {
         expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
         expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
         expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-        expect.eql(1823154.05651777.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value)
+        expect.eql(1823154.05651777.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
+        expect.eql(allowSpend.amount.value.value, spendTransaction.get.amount.value.value)
   }
 
-  test("Test swap successfully when liquidity pool exists - 10% fee") {
+  test("Test swap successfully when liquidity pool exists - 10% fee") { implicit res =>
+    implicit val (h, sp) = res
+
     val primaryToken =
       TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
     val pairToken =
       TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 2000000L.toTokenAmountFormat.toPosLongUnsafe)
     val ownerAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Ks")
-    val metagraphAddress = Address("DAG88yethVdWM44eq5riNB65XF3rfE3rGFJN15Gs")
 
     val (poolId, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress, 10L)
     val ammOnChainState = AmmOnChainState(List.empty)
@@ -110,39 +162,69 @@ object SwapCombinerTest extends SimpleIOSuite {
       Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
     )
     val state = DataState(ammOnChainState, ammCalculatedState)
-    val stakingUpdate = SwapUpdate(
-      primaryToken.identifier,
-      pairToken.identifier,
-      CurrencyId(metagraphAddress),
-      0L,
-      "",
-      "",
-      100000L.toPosLongUnsafe,
-      100000L.toPosLongUnsafe,
-      SnapshotOrdinal.unsafeApply(20),
-      none,
-      1L.toPosLongUnsafe,
-      20000.toPosLongUnsafe
-    )
-
     for {
+      keyPair <- KeyPairGenerator.makeKeyPair[IO]
+      allowSpend = AllowSpend(
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMc"),
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb"),
+        Some(CurrencyId(ownerAddress)),
+        SwapAmount(PosLong.MinValue),
+        AllowSpendFee(PosLong.MinValue),
+        AllowSpendReference(AllowSpendOrdinal.first, Hash.empty),
+        EpochProgress.MaxValue,
+        List.empty
+      )
+
+      signedAllowSpend <- Signed
+        .forAsyncHasher[IO, AllowSpend](allowSpend, keyPair)
+        .flatMap(_.toHashed[IO])
+
+      swapUpdate = SwapUpdate(
+        ownerAddress,
+        primaryToken.identifier,
+        pairToken.identifier,
+        0L,
+        "",
+        signedAllowSpend.hash,
+        SwapAmount(100000L),
+        SwapAmount(100000L),
+        EpochProgress.MaxValue,
+        none,
+        none,
+        none
+      )
+
+      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
+        keyPair,
+        SortedMap(
+          ownerAddress -> SortedSet(signedAllowSpend.signed)
+        )
+      )
       stakeResponse <- combineSwap[IO](
         state,
-        stakingUpdate,
+        swapUpdate,
         ownerAddress,
         SnapshotOrdinal.MinValue
       )
 
-      swapCalculatedState = stakeResponse.calculated.ammState(OperationType.Swap).asInstanceOf[SwapCalculatedState]
+      swapCalculatedState = stakeResponse.calculated.operations(OperationType.Swap).asInstanceOf[SwapCalculatedState]
       addressSwapResponse = swapCalculatedState.addresses(ownerAddress)
 
-      oldLiquidityPoolCalculatedState = state.calculated.ammState(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      oldLiquidityPoolCalculatedState = state.calculated.operations(OperationType.LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
       oldLiquidityPool = oldLiquidityPoolCalculatedState.liquidityPools(poolId)
 
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .ammState(OperationType.LiquidityPool)
+        .operations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId)
+
+      swapSpendTransactions = stakeResponse.sharedArtifacts.collect {
+        case transaction: artifact.SpendTransaction => transaction
+      }.collect {
+        case transaction: artifact.PendingSpendTransaction => transaction
+      }
+
+      spendTransaction = swapSpendTransactions.find(_.allowSpendRef === signedAllowSpend.hash)
     } yield
       expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
         expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
@@ -150,6 +232,7 @@ object SwapCombinerTest extends SimpleIOSuite {
         expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
         expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
         expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-        expect.eql(1834862.3853211.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value)
+        expect.eql(1834862.3853211.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
+        expect.eql(allowSpend.amount.value.value, spendTransaction.get.amount.value.value)
   }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
@@ -46,7 +46,7 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
     val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
-    val poolId = s"$primaryAddressAsString-$pairAddressAsString"
+    val poolId = PoolId(s"$primaryAddressAsString-$pairAddressAsString")
     val liquidityPool = LiquidityPool(
       poolId,
       tokenA,
@@ -57,7 +57,7 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
-    (poolId, LiquidityPoolCalculatedState(Map(poolId -> liquidityPool)))
+    (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }
 
   def getFakeSignedUpdate(

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -28,7 +28,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
 import org.amm_metagraph.shared_data.Utils.{DoubleOps, LongOps, PosLongOps}
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, LiquidityProviders, TokenInformation}
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.validations.{Errors, ValidationService}
@@ -51,7 +51,7 @@ object StakingValidationTest extends MutableIOSuite {
   ): (String, LiquidityPoolCalculatedState) = {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
     val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
-    val poolId = s"$primaryAddressAsString-$pairAddressAsString"
+    val poolId = org.amm_metagraph.shared_data.types.LiquidityPool.PoolId(s"$primaryAddressAsString-$pairAddressAsString")
     val liquidityPool = LiquidityPool(
       poolId,
       tokenA,
@@ -62,7 +62,7 @@ object StakingValidationTest extends MutableIOSuite {
       math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
       LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
     )
-    (poolId, LiquidityPoolCalculatedState(Map(poolId -> liquidityPool)))
+    (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }
 
   def getFakeSignedUpdate(


### PR DESCRIPTION
### Changes
+ Adding the validation of the allow spend when performing a swap
+ Adding the generation of the spend transaction when performing a swap
+ Adapted the current tests
+ Cleaned some parts of the code, removing unused parts
+ Update the combine to reject the update if the allowSpend already exists