### PR TITLE
feat: updating the generation of SpendTransaction to SpendAction

### DIFF
--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/StakingCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/StakingCombiner.scala
@@ -13,6 +13,7 @@ import io.constellationnetwork.schema.swap.AllowSpend
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher}
 
+import org.amm_metagraph.shared_data.SpendTransactions.generateSpendAction
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.types.DataUpdates.{AmmUpdate, StakingUpdate}
 import org.amm_metagraph.shared_data.types.LiquidityPool._
@@ -81,8 +82,8 @@ object StakingCombiner {
     allowSpendTokenA: Hashed[AllowSpend],
     allowSpendTokenB: Hashed[AllowSpend]
   ): SortedSet[SharedArtifact] = {
-    val spendTransactionTokenA = generatePendingSpendTransaction(allowSpendTokenA)
-    val spendTransactionTokenB = generatePendingSpendTransaction(allowSpendTokenB)
+    val spendTransactionTokenA = generateSpendAction(allowSpendTokenA)
+    val spendTransactionTokenB = generateSpendAction(allowSpendTokenB)
     SortedSet[SharedArtifact](
       spendTransactionTokenA,
       spendTransactionTokenB

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/SwapCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/SwapCombiner.scala
@@ -2,21 +2,20 @@ package org.amm_metagraph.shared_data.combiners
 
 import cats.effect.Async
 import cats.syntax.all._
-
-import scala.collection.immutable.SortedSet
-
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SharedArtifact
 import io.constellationnetwork.security.Hasher
 import io.constellationnetwork.security.signature.Signed
-
+import org.amm_metagraph.shared_data.SpendTransactions.generateSpendAction
 import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, TokenInformation, getLiquidityPools}
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.Swap._
+
+import scala.collection.immutable.SortedSet
 
 object SwapCombiner {
   private def getUpdatedTokenInformation(
@@ -127,7 +126,7 @@ object SwapCombiner {
             .updated(OperationType.Swap, newSwapState)
             .updated(OperationType.LiquidityPool, newLiquidityPoolState)
 
-          spendTransaction: SharedArtifact = generatePendingSpendTransaction(hashedAllowSpend)
+          spendTransaction: SharedArtifact = generateSpendAction(hashedAllowSpend)
 
         } yield
           DataState(


### PR DESCRIPTION
### Changes
+ Updating the flow to generate SpendAction instead of SpendTransaction directly
+ This change respects the update of notion doc: https://www.notion.so/Currency-Swapping-cf462ad9c01d4e93902429282e7267e8#e1668bee754d49bb9f8cfb2001fde0ea

### Note
+ The output SpendTransaction is not valid yet, it's just a placeholder so we can replace it when we have the final flow