### PR TITLE
feat: generalizing pending updates to be flexible to use in different DataUpdates

### DIFF
--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/custom_routes/CustomRoutes.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/custom_routes/CustomRoutes.scala
@@ -16,7 +16,7 @@ import eu.timepit.refined.auto._
 import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
-import org.amm_metagraph.shared_data.types.Swap.{SwapCalculatedStateAddress, getSwapCalculatedState}
+import org.amm_metagraph.shared_data.types.Swap.{SwapCalculatedStateAddress, getPendingSwapUpdates, getSwapCalculatedState}
 import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.middleware.CORS
@@ -82,7 +82,8 @@ case class CustomRoutes[F[_]: Async](calculatedStateService: CalculatedStateServ
       calculatedState <- calculatedStateService.get
       allowSpendHash = Hash(allowSpendHashString)
       swapCalculatedState = getSwapCalculatedState(calculatedState.state)
-      result <- swapCalculatedState.pending.values.flatten
+      pendingSwaps = getPendingSwapUpdates(calculatedState.state)
+      result <- pendingSwaps
         .find(_.value.allowSpendReference === allowSpendHash)
         .map(buildPendingSwapResponse)
         .orElse {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/SpendTransactions.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/SpendTransactions.scala
@@ -1,18 +1,19 @@
 package org.amm_metagraph.shared_data
 
+import scala.collection.immutable.SortedSet
+
 import io.constellationnetwork.schema.artifact._
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap.AllowSpend
 import io.constellationnetwork.security.Hashed
-import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 
-import scala.collection.immutable.SortedSet
+import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 
 object SpendTransactions {
 
   def generateSpendAction(
     hashedAllowSpend: Hashed[AllowSpend]
-  ): SpendAction = {
+  ): SpendAction =
     SpendAction(
       PendingSpendTransaction(
         SpendTransactionFee(hashedAllowSpend.fee.value),
@@ -29,8 +30,7 @@ object SpendTransactions {
         hashedAllowSpend.amount
       )
     )
-  }
-  
+
   def getCalculatedStateSpendTransactions(
     calculatedState: AmmCalculatedState
   ): (SortedSet[PendingSpendTransaction], SortedSet[ConcludedSpendTransaction]) =

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
@@ -10,5 +10,5 @@ case class CalculatedState(ordinal: SnapshotOrdinal, state: AmmCalculatedState)
 
 object CalculatedState {
   def empty: CalculatedState =
-    CalculatedState(SnapshotOrdinal.MinValue, AmmCalculatedState(Map.empty, SortedSet.empty))
+    CalculatedState(SnapshotOrdinal.MinValue, AmmCalculatedState(Map.empty, Set.empty, SortedSet.empty))
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
@@ -37,14 +37,15 @@ object CalculatedStateService {
         ): F[Boolean] =
           stateRef.modify { currentState =>
             val currentCalculatedState = currentState.state
-            val updatedOperations = state.operations.foldLeft(currentCalculatedState.operations) {
+            val updatedOperations = state.confirmedOperations.foldLeft(currentCalculatedState.confirmedOperations) {
               case (acc, (address, value)) =>
                 acc.updated(address, value)
             }
 
+            val updatedPendingUpdates = currentCalculatedState.pendingUpdates ++ state.pendingUpdates
             val updatedSpendTransactions = currentCalculatedState.spendTransactions ++ state.spendTransactions
 
-            (CalculatedState(snapshotOrdinal, AmmCalculatedState(updatedOperations, updatedSpendTransactions)), true)
+            (CalculatedState(snapshotOrdinal, AmmCalculatedState(updatedOperations, updatedPendingUpdates, updatedSpendTransactions)), true)
           }
 
         override def hash(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
@@ -44,7 +44,7 @@ object LiquidityPoolCombiner {
         LiquidityProviders(Map(signerAddress -> poolTotalLiquidity))
       )
       updatedLiquidityPoolCalculatedState = LiquidityPoolCalculatedState(liquidityPools.updated(poolId.value, liquidityPool))
-      updatedState = acc.calculated.operations.updated(OperationType.LiquidityPool, updatedLiquidityPoolCalculatedState)
+      updatedState = acc.calculated.confirmedOperations.updated(OperationType.LiquidityPool, updatedLiquidityPoolCalculatedState)
       updates: List[AmmUpdate] = liquidityPoolUpdate :: acc.onChain.updates
     } yield
       DataState(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawCombiner.scala
@@ -17,7 +17,7 @@ object WithdrawCombiner {
     val withdrawUpdate = signedWithdrawUpdate.value
 
     val withdrawCalculatedStateAddresses =
-      acc.calculated.operations.get(OperationType.Withdraw).fold(Map.empty[Address, WithdrawCalculatedStateAddress]) {
+      acc.calculated.confirmedOperations.get(OperationType.Withdraw).fold(Map.empty[Address, WithdrawCalculatedStateAddress]) {
         case stakingCalculatedState: WithdrawCalculatedState => stakingCalculatedState.addresses
         case _                                               => Map.empty
       }
@@ -28,7 +28,7 @@ object WithdrawCombiner {
     val updatedWithdrawCalculatedState = WithdrawCalculatedState(
       withdrawCalculatedStateAddresses.updated(signerAddress, withdrawCalculatedStateAddress)
     )
-    val updatedState = acc.calculated.operations.updated(OperationType.Withdraw, updatedWithdrawCalculatedState)
+    val updatedState = acc.calculated.confirmedOperations.updated(OperationType.Withdraw, updatedWithdrawCalculatedState)
     val updates: List[AmmUpdate] = withdrawUpdate :: acc.onChain.updates
 
     DataState(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
@@ -39,7 +39,7 @@ object LiquidityPool {
   )
 
   def getLiquidityPools(state: AmmCalculatedState): Map[String, LiquidityPool] =
-    state.operations.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
+    state.confirmedOperations.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
       case liquidityPoolsCalculatedState: LiquidityPoolCalculatedState => liquidityPoolsCalculatedState.liquidityPools
       case _                                                           => Map.empty
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
@@ -2,9 +2,11 @@ package org.amm_metagraph.shared_data.types
 
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
+import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
 import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, OperationType, StakingCalculatedState}
 
@@ -31,8 +33,16 @@ object Staking {
   def getStakingCalculatedState(
     calculatedState: AmmCalculatedState
   ): StakingCalculatedState =
-    calculatedState.operations
+    calculatedState.confirmedOperations
       .get(OperationType.Staking)
       .collect { case t: StakingCalculatedState => t }
       .getOrElse(StakingCalculatedState.empty)
+
+  def getPendingStakeUpdates(
+    state: AmmCalculatedState
+  ): Set[Signed[StakingUpdate]] =
+    state.pendingUpdates.collect {
+      case pendingUpdate @ Signed(stakingUpdate: StakingUpdate, _) =>
+        Signed(stakingUpdate, pendingUpdate.proofs)
+    }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
@@ -10,7 +10,7 @@ import io.constellationnetwork.security.signature.Signed
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import enumeratum.values.{StringCirceEnum, StringEnum, StringEnumEntry}
-import org.amm_metagraph.shared_data.types.DataUpdates.{AmmUpdate, StakingUpdate, SwapUpdate}
+import org.amm_metagraph.shared_data.types.DataUpdates.AmmUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress
 import org.amm_metagraph.shared_data.types.Swap.SwapCalculatedStateAddress
@@ -32,12 +32,11 @@ object States {
 
   @derive(encoder, decoder)
   case class StakingCalculatedState(
-    confirmed: Map[Address, Set[StakingCalculatedStateAddress]],
-    pending: Map[Address, Set[Signed[StakingUpdate]]]
+    confirmed: Map[Address, Set[StakingCalculatedStateAddress]]
   ) extends AmmOffChainState
 
   object StakingCalculatedState {
-    def empty: StakingCalculatedState = StakingCalculatedState(Map.empty, Map.empty)
+    def empty: StakingCalculatedState = StakingCalculatedState(Map.empty)
   }
 
   @derive(encoder, decoder)
@@ -47,12 +46,11 @@ object States {
 
   @derive(encoder, decoder)
   case class SwapCalculatedState(
-    confirmed: Map[Address, Set[SwapCalculatedStateAddress]],
-    pending: Map[Address, Set[Signed[SwapUpdate]]]
+    confirmed: Map[Address, Set[SwapCalculatedStateAddress]]
   ) extends AmmOffChainState
 
   object SwapCalculatedState {
-    def empty: SwapCalculatedState = SwapCalculatedState(Map.empty, Map.empty)
+    def empty: SwapCalculatedState = SwapCalculatedState(Map.empty)
   }
 
   @derive(encoder, decoder)
@@ -72,7 +70,8 @@ object States {
 
   @derive(encoder, decoder)
   case class AmmCalculatedState(
-    operations: Map[OperationType, AmmOffChainState],
+    confirmedOperations: Map[OperationType, AmmOffChainState],
+    pendingUpdates: Set[Signed[AmmUpdate]] = Set.empty[Signed[AmmUpdate]],
     spendTransactions: SortedSet[SpendTransaction] = SortedSet.empty[SpendTransaction]
   ) extends DataCalculatedState
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
@@ -5,11 +5,13 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap.SwapAmount
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
 import io.circe.refined._
+import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, OperationType, SwapCalculatedState}
 
@@ -33,8 +35,16 @@ object Swap {
   def getSwapCalculatedState(
     calculatedState: AmmCalculatedState
   ): SwapCalculatedState =
-    calculatedState.operations
+    calculatedState.confirmedOperations
       .get(OperationType.Swap)
       .collect { case t: SwapCalculatedState => t }
       .getOrElse(SwapCalculatedState.empty)
+
+  def getPendingSwapUpdates(
+    state: AmmCalculatedState
+  ): Set[Signed[SwapUpdate]] =
+    state.pendingUpdates.collect {
+      case pendingUpdate @ Signed(swapUpdate: SwapUpdate, _) =>
+        Signed(swapUpdate, pendingUpdate.proofs)
+    }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
@@ -12,7 +12,7 @@ import io.constellationnetwork.currency.schema.currency
 import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.epoch.EpochProgress
-import io.constellationnetwork.schema.swap.AllowSpend
+import io.constellationnetwork.schema.swap.{AllowSpend, CurrencyId}
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
@@ -53,12 +53,12 @@ object DummyL0Context {
     gsEpochProgress: EpochProgress = EpochProgress.MinValue
   ): L0NodeContext[F] =
     new L0NodeContext[F] {
-      override def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
-
-      override def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = for {
-        globalIncrementalSnapshot <- buildGlobalIncrementalSnapshot[F](keyPair, gsEpochProgress)
-        globalSnapshotInfo = buildGlobalSnapshotInfo(allowSpends)
-      } yield Some((globalIncrementalSnapshot, globalSnapshotInfo))
+//      override def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
+//
+//      override def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = for {
+//        globalIncrementalSnapshot <- buildGlobalIncrementalSnapshot[F](keyPair, gsEpochProgress)
+//        globalSnapshotInfo = buildGlobalSnapshotInfo(allowSpends)
+//      } yield Some((globalIncrementalSnapshot, globalSnapshotInfo))
 
       override def getLastCurrencySnapshot: F[Option[Hashed[currency.CurrencyIncrementalSnapshot]]] = ???
 
@@ -69,7 +69,7 @@ object DummyL0Context {
 
       override def securityProvider: SecurityProvider[F] = ???
 
-      override def getMetagraphId: F[Address] = metagraphAddress.pure[F]
+      override def getCurrencyId: F[CurrencyId] = CurrencyId(metagraphAddress).pure[F]
     }
 
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -64,7 +64,7 @@ object LiquidityPoolCombinerTest extends SimpleIOSuite {
       )
       poolId <- buildLiquidityPoolUniqueIdentifier(primaryToken.identifier, pairToken.identifier)
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .operations(OperationType.LiquidityPool)
+        .confirmedOperations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId.value)
     } yield
@@ -98,7 +98,7 @@ object LiquidityPoolCombinerTest extends SimpleIOSuite {
       )
       poolId <- buildLiquidityPoolUniqueIdentifier(primaryToken.identifier, pairToken.identifier)
       updatedLiquidityPoolCalculatedState = stakeResponse.calculated
-        .operations(OperationType.LiquidityPool)
+        .confirmedOperations(OperationType.LiquidityPool)
         .asInstanceOf[LiquidityPoolCalculatedState]
       updatedLiquidityPool = updatedLiquidityPoolCalculatedState.liquidityPools(poolId.value)
     } yield

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -235,8 +235,7 @@ object StakingValidationTest extends MutableIOSuite {
                 none
               )
             )
-          ),
-          Map.empty
+          )
         )
       )
     )


### PR DESCRIPTION
### Changes
+ We need to expand the pending updates to be used in different update types, such as Swap and Staking (in the next tickets also in LiquidityPool creation)
+ This PR aims to let the pending updates as a data structure in the CalculatedState