### PR TITLE
feat: adding voting allocations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ ThisBuild / scalaVersion := "2.13.14"
 ThisBuild / evictionErrorLevel := Level.Warn
 ThisBuild / scalafixDependencies += Libraries.organizeImports
 
-
 ThisBuild / assemblyMergeStrategy := {
-  case "logback.xml" => MergeStrategy.first
-  case x if x.contains("io.netty.versions.properties") => MergeStrategy.discard
-  case PathList(xs@_*) if xs.last == "module-info.class" => MergeStrategy.first
+  case "logback.xml"                                       => MergeStrategy.first
+  case x if x.contains("io.netty.versions.properties")     => MergeStrategy.discard
+  case PathList(xs @ _*) if xs.last == "module-info.class" => MergeStrategy.first
+  case x if x.contains("rally-version.properties")         => MergeStrategy.concat
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
@@ -30,10 +30,11 @@ lazy val commonTestSettings = Seq(
   ).map(_ % Test)
 )
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "amm_metagraph"
-  ).aggregate(sharedData, currencyL0, currencyL1, dataL1)
+  )
+  .aggregate(sharedData, currencyL0, currencyL1, dataL1)
 
 lazy val sharedData = (project in file("modules/shared_data"))
   .enablePlugins(AshScriptPlugin)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
@@ -52,7 +52,8 @@ object CalculatedStateService {
                   updatedOperations,
                   updatedPendingUpdates,
                   updatedSpendTransactions,
-                  state.votingWeights
+                  state.votingWeights,
+                  state.allocations
                 )
               ),
               true

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/CombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/CombinerService.scala
@@ -5,18 +5,18 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
-import io.constellationnetwork.currency.schema.currency.CurrencySnapshotInfo
 import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
-import io.constellationnetwork.schema.SnapshotOrdinal
-import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.balance.Amount
+import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, SecurityProvider}
 
-import eu.timepit.refined.types.numeric.NonNegLong
 import monocle.syntax.all._
 import org.amm_metagraph.shared_data.SpendTransactions.getCombinedSpendTransactions
-import org.amm_metagraph.shared_data.Utils.toAddress
+import org.amm_metagraph.shared_data.combiners.GovernanceCombiner.{
+  cleanExpiredAllocations,
+  combineRewardAllocationVoteUpdate,
+  updateVotingWeights
+}
 import org.amm_metagraph.shared_data.combiners.LiquidityPoolCombiner.combineLiquidityPool
 import org.amm_metagraph.shared_data.combiners.StakingCombiner.combineStaking
 import org.amm_metagraph.shared_data.combiners.SwapCombiner.combineSwap
@@ -37,103 +37,99 @@ object CombinerService {
     new CombinerService[F] {
       def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("CombinerService")
 
-      private def updateVotingWeights(
-        currentCalculatedState: AmmCalculatedState,
-        lastCurrencySnapshotInfo: CurrencySnapshotInfo
-      ): Map[Address, VotingWeight] =
-        lastCurrencySnapshotInfo.activeTokenLocks.map {
-          _.foldLeft(Map.empty[Address, VotingWeight]) { (acc, current) =>
-            val (address, tokenLocks) = current
-            val tokenLocksAmount = NonNegLong
-              .from(
-                tokenLocks.map(_.amount.value.value).sum
-              )
-              .getOrElse(NonNegLong.MinValue)
-            val votingWeight = VotingWeight(Amount(tokenLocksAmount))
-            acc.updated(address, votingWeight)
-          }
-        }.getOrElse(currentCalculatedState.votingWeights)
-
       override def combine(
         oldState: DataState[AmmOnChainState, AmmCalculatedState],
         incomingUpdates: List[Signed[AmmUpdate]]
-      )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] = for {
-        (_, lastCurrencySnapshotInfo) <- OptionT(context.getLastCurrencySnapshotCombined).getOrRaise(
-          new IllegalStateException("lastCurrencySnapshot unavailable")
-        )
+      )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] =
+        (for {
+          (lastCurrencySnapshot, lastCurrencySnapshotInfo) <- OptionT(context.getLastCurrencySnapshotCombined).getOrRaise(
+            new IllegalStateException("lastCurrencySnapshot unavailable")
+          )
+          lastSyncGlobalEpochProgress <- OptionT(context.getLastSynchronizedGlobalSnapshot)
+            .map(_.epochProgress)
+            .getOrElseF {
+              val message = "Could not get lastSyncGlobalEpochProgress"
+              logger.error(message) >> new Exception(message).raiseError[F, EpochProgress]
+            }
+          currentSnapshotOrdinal = lastCurrencySnapshot.ordinal.next
 
-        newState =
-          DataState(
-            AmmOnChainState(List.empty),
-            AmmCalculatedState(
-              oldState.calculated.confirmedOperations,
-              oldState.calculated.pendingUpdates,
-              oldState.calculated.spendTransactions
+          newState =
+            DataState(
+              AmmOnChainState(List.empty),
+              oldState.calculated
             )
+
+          pendingUpdates = oldState.calculated.pendingUpdates
+          updates = incomingUpdates ++ pendingUpdates
+
+          updatedVotingWeights = updateVotingWeights(
+            newState.calculated,
+            lastCurrencySnapshotInfo,
+            lastSyncGlobalEpochProgress
           )
 
-        pendingUpdates = oldState.calculated.pendingUpdates
-        updates = incomingUpdates ++ pendingUpdates
+          updatedVotingWeightState = newState.calculated
+            .focus(_.votingWeights)
+            .replace(updatedVotingWeights)
 
-        stateCombinedByUpdates <-
-          if (updates.isEmpty) {
-            logger.info("Snapshot without any updates, updating the state to empty updates").as(newState)
-          } else {
-            logger.info(s"Incoming updates: ${incomingUpdates.size}") >>
-              logger.info(s"Pending updates: ${pendingUpdates.size}") >>
-              updates.foldLeftM(newState) { (acc, signedUpdate) =>
-                for {
-                  address <- toAddress(signedUpdate.proofs.head)
-                  currentSnapshotOrdinal <- OptionT(context.getLastCurrencySnapshot)
-                    .map(_.ordinal.next)
-                    .getOrElseF {
-                      val message = "Could not get the ordinal from currency snapshot. lastCurrencySnapshot not found"
-                      logger.error(message) >> new Exception(message).raiseError[F, SnapshotOrdinal]
+          stateCombinedByVotingWeight = newState
+            .focus(_.calculated)
+            .replace(updatedVotingWeightState)
+
+          stateCombinedByUpdates <-
+            if (updates.isEmpty) {
+              logger.info("Snapshot without any updates, updating the state to empty updates").as(stateCombinedByVotingWeight)
+            } else {
+              logger.info(s"Incoming updates: ${incomingUpdates.size}") >>
+                logger.info(s"Pending updates: ${pendingUpdates.size}") >>
+                updates.foldLeftM(stateCombinedByVotingWeight) { (acc, signedUpdate) =>
+                  for {
+                    address <- signedUpdate.proofs.head.id.toAddress
+
+                    combinedState <- signedUpdate.value match {
+                      case stakingUpdate: StakingUpdate =>
+                        logger.info(s"Received staking update: $stakingUpdate") >>
+                          combineStaking(acc, Signed(stakingUpdate, signedUpdate.proofs), address, currentSnapshotOrdinal)
+
+                      case liquidityPoolUpdate: LiquidityPoolUpdate =>
+                        logger.info(s"Received liquidity pool update: $liquidityPoolUpdate") >>
+                          combineLiquidityPool(acc, Signed(liquidityPoolUpdate, signedUpdate.proofs), address)
+
+                      case swapUpdate: SwapUpdate =>
+                        logger.info(s"Received swap update: $swapUpdate") >>
+                          combineSwap(acc, Signed(swapUpdate, signedUpdate.proofs), currentSnapshotOrdinal)
+
+                      case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate =>
+                        logger.info(s"Received reward allocation vote update: $rewardAllocationVoteUpdate") >>
+                          combineRewardAllocationVoteUpdate(
+                            acc,
+                            Signed(rewardAllocationVoteUpdate, signedUpdate.proofs),
+                            lastSyncGlobalEpochProgress
+                          )
                     }
-                  combinedState <- signedUpdate.value match {
-                    case stakingUpdate: StakingUpdate =>
-                      logger.info(s"Received staking update: $stakingUpdate") >>
-                        combineStaking(acc, Signed(stakingUpdate, signedUpdate.proofs), address, currentSnapshotOrdinal)
 
-                    case liquidityPoolUpdate: LiquidityPoolUpdate =>
-                      logger.info(s"Received liquidity pool update: $liquidityPoolUpdate") >>
-                        combineLiquidityPool(acc, Signed(liquidityPoolUpdate, signedUpdate.proofs), address)
+                    spendTransactions = getCombinedSpendTransactions(
+                      combinedState.sharedArtifacts
+                    )
 
-                    case swapUpdate: SwapUpdate =>
-                      logger.info(s"Received swap update: $swapUpdate") >>
-                        combineSwap(acc, Signed(swapUpdate, signedUpdate.proofs), currentSnapshotOrdinal)
-                  }
+                    updatedState <-
+                      combinedState
+                        .focus(_.calculated)
+                        .modify(_ =>
+                          combinedState.calculated
+                            .focus(_.spendTransactions)
+                            .modify(current => current ++ spendTransactions)
+                        )
+                        .pure
+                  } yield updatedState
+                }
+            }
 
-                  spendTransactions = getCombinedSpendTransactions(
-                    combinedState.sharedArtifacts
-                  )
+          stateCombinedCleaningAllocations = cleanExpiredAllocations(stateCombinedByUpdates, lastSyncGlobalEpochProgress)
 
-                  updatedState <-
-                    combinedState
-                      .focus(_.calculated)
-                      .modify(_ =>
-                        combinedState.calculated
-                          .focus(_.spendTransactions)
-                          .modify(current => current ++ spendTransactions)
-                      )
-                      .pure
-                } yield updatedState
-              }
-          }
-
-        updatedVotingWeights = updateVotingWeights(
-          stateCombinedByUpdates.calculated,
-          lastCurrencySnapshotInfo
-        )
-
-        updatedVotingWeightState = stateCombinedByUpdates.calculated
-          .focus(_.votingWeights)
-          .replace(updatedVotingWeights)
-
-        stateCombinedByVotingWeight = stateCombinedByUpdates
-          .focus(_.calculated)
-          .replace(updatedVotingWeightState)
-      } yield stateCombinedByVotingWeight
+        } yield stateCombinedCleaningAllocations).handleErrorWith { e =>
+          logger.error(s"Error when combining: ${e.getMessage}").as(oldState)
+        }
     }
   }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/GovernanceCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/GovernanceCombiner.scala
@@ -1,0 +1,174 @@
+package org.amm_metagraph.shared_data.combiners
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.DataState
+import io.constellationnetwork.currency.schema.currency.CurrencySnapshotInfo
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.tokenLock.TokenLock
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.Signed
+
+import monocle.syntax.all._
+import org.amm_metagraph.shared_data.credits.getUpdatedCredits
+import org.amm_metagraph.shared_data.epochProgress.{epochProgress1Year, epochProgress2Years}
+import org.amm_metagraph.shared_data.refined._
+import org.amm_metagraph.shared_data.types.DataUpdates.RewardAllocationVoteUpdate
+import org.amm_metagraph.shared_data.types.Governance.AllocationEpochProgressInfo.getAllocationEpochProgressInfo
+import org.amm_metagraph.shared_data.types.Governance._
+import org.amm_metagraph.shared_data.types.LiquidityPool.getLiquidityPoolCalculatedState
+import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, AmmOnChainState}
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object GovernanceCombiner {
+  private val sixMonthsMultiplier: Double = 0.25
+  private val oneYearMultiplier: Double = 0.5
+  private val twoYearsMultiplier: Double = 1
+
+  def updateVotingWeights(
+    currentCalculatedState: AmmCalculatedState,
+    lastCurrencySnapshotInfo: CurrencySnapshotInfo,
+    lastSyncGlobalSnapshotEpochProgress: EpochProgress
+  ): Map[Address, VotingWeight] = {
+    val currentVotingWeights = currentCalculatedState.votingWeights
+
+    lastCurrencySnapshotInfo.activeTokenLocks.map { activeTokenLocks =>
+      activeTokenLocks.foldLeft(currentVotingWeights) { (acc, tokenLocksInfo) =>
+        val (address, tokenLocks) = tokenLocksInfo
+        val currentAddressVotingWeight = acc.getOrElse(address, VotingWeight.empty)
+
+        val currentTokenLocks = currentAddressVotingWeight.info.map(_.tokenLock).toSet
+        val fetchedTokenLocks = tokenLocks.map(_.value)
+
+        val removedTokenLocks = currentTokenLocks.diff(fetchedTokenLocks)
+        val addedTokenLocks = fetchedTokenLocks.diff(currentTokenLocks)
+
+        val updatedInfo =
+          updateVotingWeightInfo(currentAddressVotingWeight.info, addedTokenLocks, removedTokenLocks, lastSyncGlobalSnapshotEpochProgress)
+        val updatedWeight = updatedInfo.map(_.weight.value).sum
+
+        acc.updated(address, VotingWeight(updatedWeight.toNonNegDoubleUnsafe, updatedInfo))
+      }
+    }
+      .getOrElse(currentVotingWeights)
+  }
+
+  private def updateVotingWeightInfo(
+    currentVotingWeightInfo: List[VotingWeightInfo],
+    addedTokenLocks: Set[TokenLock],
+    removedTokenLocks: Set[TokenLock],
+    lastSyncGlobalSnapshotEpochProgress: EpochProgress
+  ): List[VotingWeightInfo] = {
+    val filteredInfo = currentVotingWeightInfo.filterNot(info => removedTokenLocks.contains(info.tokenLock))
+
+    val newInfo = addedTokenLocks.toList.map { lock =>
+      val weight = calculateWeight(lock, lastSyncGlobalSnapshotEpochProgress)
+      VotingWeightInfo(weight.toNonNegDoubleUnsafe, lock)
+    }
+
+    filteredInfo ++ newInfo
+  }
+
+  private def calculateWeight(
+    tokenLock: TokenLock,
+    lastSyncGlobalSnapshotEpochProgress: EpochProgress
+  ): Double = {
+    val unlockEpochValue = tokenLock.unlockEpoch.value.value
+    val syncEpochProgressValue = lastSyncGlobalSnapshotEpochProgress.value.value
+
+    if (syncEpochProgressValue + epochProgress2Years >= unlockEpochValue) {
+      tokenLock.amount.value.value * twoYearsMultiplier
+    } else if (syncEpochProgressValue + epochProgress1Year >= unlockEpochValue) {
+      tokenLock.amount.value.value * oneYearMultiplier
+    } else {
+      tokenLock.amount.value.value * sixMonthsMultiplier
+    }
+  }
+
+  def combineRewardAllocationVoteUpdate[F[_]: Async: Hasher](
+    acc: DataState[AmmOnChainState, AmmCalculatedState],
+    signedRewardAllocationVoteUpdate: Signed[RewardAllocationVoteUpdate],
+    globalEpochProgress: EpochProgress
+  ): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
+    def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("GovernanceCombiner")
+
+    val liquidityPools = getLiquidityPoolCalculatedState(acc.calculated).liquidityPools
+
+    RewardAllocationVoteReference.of(signedRewardAllocationVoteUpdate).flatMap { reference =>
+      val allocationsSum = signedRewardAllocationVoteUpdate.allocations.map { case (_, weight) => weight.value }.sum
+      val userVotingWeight = acc.calculated.votingWeights.getOrElse(signedRewardAllocationVoteUpdate.address, VotingWeight.empty)
+
+      val allocationsUpdate = signedRewardAllocationVoteUpdate.allocations.map {
+        case (key, weight) =>
+          val votingWeight = userVotingWeight.total.value * (weight.value / allocationsSum.toDouble)
+          val category = if (liquidityPools.contains(key)) {
+            AllocationCategory.LiquidityPool
+          } else {
+            AllocationCategory.NodeOperator
+          }
+
+          Allocation(AllocationId(key), category, votingWeight.toNonNegDoubleUnsafe)
+      }.toList
+      val allocationEpochProgressInfo = getAllocationEpochProgressInfo(globalEpochProgress)
+
+      acc.calculated.allocations
+        .get(signedRewardAllocationVoteUpdate.address)
+        .fold {
+          UserAllocations(
+            maxCredits,
+            reference,
+            allocationEpochProgressInfo,
+            allocationsUpdate
+          ).pure
+        } { existing =>
+          getUpdatedCredits(
+            existing.allocationEpochProgressInfo.allocationGlobalEpochProgress.value.value,
+            existing.credits,
+            globalEpochProgress.value.value,
+            maxCredits
+          ).fold(
+            msg => logger.warn(s"Error when combining reward allocation: $msg").as(existing),
+            updatedCredits =>
+              UserAllocations(
+                updatedCredits,
+                reference,
+                allocationEpochProgressInfo,
+                allocationsUpdate
+              ).pure
+          )
+        }
+        .map { allocationsCalculatedState =>
+          val updatedAllocations = acc.calculated
+            .focus(_.allocations)
+            .modify(_.updated(signedRewardAllocationVoteUpdate.address, allocationsCalculatedState))
+
+          acc.focus(_.calculated).replace(updatedAllocations)
+        }
+    }
+  }
+
+  def cleanExpiredAllocations(
+    acc: DataState[AmmOnChainState, AmmCalculatedState],
+    globalEpochProgress: EpochProgress
+  ): DataState[AmmOnChainState, AmmCalculatedState] = {
+    val filteredAllocations = acc.calculated.allocations.map {
+      case (address, allocations) =>
+        val isExpired = globalEpochProgress > allocations.allocationEpochProgressInfo.expireGlobalEpochProgress
+
+        val matchesVotingWeight = acc.calculated.votingWeights.get(address).exists { votingWeight =>
+          votingWeight.total == allocations.allocations.map(_.weight.value).sum.toNonNegDoubleUnsafe
+        }
+
+        if (!isExpired && matchesVotingWeight) {
+          address -> allocations
+        } else {
+          address -> allocations.copy(allocations = List.empty)
+        }
+    }
+
+    acc.focus(_.calculated.allocations).replace(filteredAllocations)
+  }
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombiner.scala
@@ -14,7 +14,8 @@ import io.constellationnetwork.security.{Hashed, Hasher}
 
 import monocle.syntax.all._
 import org.amm_metagraph.shared_data.SpendTransactions.generateSpendAction
-import org.amm_metagraph.shared_data.Utils._
+import org.amm_metagraph.shared_data.globalSnapshots.{getAllowSpendLastSyncGlobalSnapshotState, getLastSyncGlobalIncrementalSnapshot}
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/StakingCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/StakingCombiner.scala
@@ -15,7 +15,8 @@ import io.constellationnetwork.security.{Hashed, Hasher}
 
 import monocle.syntax.all._
 import org.amm_metagraph.shared_data.SpendTransactions.generateSpendAction
-import org.amm_metagraph.shared_data.Utils._
+import org.amm_metagraph.shared_data.globalSnapshots.{getAllowSpendLastSyncGlobalSnapshotState, getLastSyncGlobalIncrementalSnapshot}
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.Staking.{

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/SwapCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/SwapCombiner.scala
@@ -13,9 +13,10 @@ import io.constellationnetwork.security.signature.Signed
 
 import monocle.syntax.all._
 import org.amm_metagraph.shared_data.SpendTransactions.generateSpendAction
-import org.amm_metagraph.shared_data.Utils._
+import org.amm_metagraph.shared_data.globalSnapshots.{getAllowSpendLastSyncGlobalSnapshotState, getLastSyncGlobalIncrementalSnapshot}
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates._
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, TokenInformation, getLiquidityPools}
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.Swap._
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/credits.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/credits.scala
@@ -1,0 +1,27 @@
+package org.amm_metagraph.shared_data
+
+import org.amm_metagraph.shared_data.epochProgress.epochProgressOneDay
+
+object credits {
+  def getUpdatedCredits(
+    lastUpdateEpoch: Long,
+    lastUpdateCredits: Double,
+    currentEpoch: Long,
+    maxCredits: Double
+  ): Either[String, Double] = {
+    val regenerationRate = maxCredits / epochProgressOneDay
+
+    val elapsedEpochs = currentEpoch - lastUpdateEpoch
+    if (elapsedEpochs < 0) return Left("Invalid epoch: time went backwards")
+
+    val regeneratedCredits = elapsedEpochs * regenerationRate
+    val updatedCredits = Math.min(lastUpdateCredits + regeneratedCredits, maxCredits)
+
+    if (updatedCredits < 1) {
+      Left("Not enough credits to make an update")
+    } else {
+      val finalCredits = updatedCredits - 1
+      Right(finalCredits)
+    }
+  }
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/epochProgress.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/epochProgress.scala
@@ -1,0 +1,13 @@
+package org.amm_metagraph.shared_data
+
+import scala.concurrent.duration._
+
+object epochProgress {
+  private val oneEpochProgress = 43.seconds
+
+  val oneEpochProgressInSeconds: Int = oneEpochProgress.toSeconds.toInt
+  val epochProgressOneDay: Int = (1.day / oneEpochProgress).toInt
+  val epochProgress6Months: Long = epochProgressOneDay * 180L
+  val epochProgress1Year: Long = epochProgress6Months * 2
+  val epochProgress2Years: Long = epochProgress1Year * 2
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/globalSnapshots.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/globalSnapshots.scala
@@ -1,6 +1,5 @@
 package org.amm_metagraph.shared_data
 
-import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
 
@@ -8,40 +7,19 @@ import scala.collection.immutable.{SortedMap, SortedSet}
 
 import io.constellationnetwork.currency.dataApplication.L0NodeContext
 import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.swap.{AllowSpend, CurrencyId}
+import io.constellationnetwork.schema.swap.AllowSpend
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
-import io.constellationnetwork.security.signature.signature.SignatureProof
-import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
+import io.constellationnetwork.security.{Hashed, Hasher}
 
-import eu.timepit.refined.types.numeric.PosLong
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, PoolId}
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-object Utils {
-  def logger[F[_]: Async]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Utils")
-
-  def toAddress[F[_]: Async: SecurityProvider](proof: SignatureProof): F[Address] =
-    proof.id.toAddress
-
-  def buildLiquidityPoolUniqueIdentifier[F[_]: MonadThrow](
-    maybeTokenAId: Option[CurrencyId],
-    maybeTokenBId: Option[CurrencyId]
-  ): F[PoolId] =
-    SortedSet(maybeTokenAId, maybeTokenBId).flatten
-      .mkString("-")
-      .pure[F]
-      .ensure(new IllegalArgumentException("You should provide at least one currency token identifier"))(_.nonEmpty)
-      .map(PoolId(_))
-
-  // TODO: Remove this in the future, it's just used to mock while context.getLastSynchronizedGlobalSnapshotCombined isn't ready
-  private def getLastSynchronizedGlobalSnapshotCombined[F[_]: Async]: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] =
-    none.pure[F]
-
+object globalSnapshots {
+  def logger[F[_]: Async]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("globalSnapshots")
   def getLastSyncGlobalIncrementalSnapshot[F[_]: Async](implicit context: L0NodeContext[F]): F[Hashed[GlobalIncrementalSnapshot]] =
-    getLastSynchronizedGlobalSnapshotCombined.flatMap {
+    context.getLastSynchronizedGlobalSnapshotCombined.flatMap {
       case Some(value) =>
         val (globalIncrementalSnapshot, _) = value
         globalIncrementalSnapshot.pure
@@ -51,7 +29,7 @@ object Utils {
     }
 
   def getLastSyncGlobalSnapshotState[F[_]: Async](implicit context: L0NodeContext[F]): F[GlobalSnapshotInfo] =
-    getLastSynchronizedGlobalSnapshotCombined.flatMap {
+    context.getLastSynchronizedGlobalSnapshotCombined.flatMap {
       case Some(value) =>
         val (_, snapshotInfo) = value
         snapshotInfo.pure
@@ -78,31 +56,4 @@ object Utils {
     }
   } yield response
 
-  def getLiquidityPoolByPoolId[F[_]: Async](
-    liquidityPoolsCalculatedState: Map[String, LiquidityPool],
-    poolId: PoolId
-  ): F[LiquidityPool] =
-    liquidityPoolsCalculatedState
-      .get(poolId.value)
-      .fold(
-        Async[F].raiseError[LiquidityPool](new IllegalStateException("Liquidity Pool does not exist"))
-      )(Async[F].pure)
-
-  implicit class PosLongOps(value: Long) {
-    def toPosLongUnsafe: PosLong =
-      PosLong.unsafeFrom(value)
-  }
-
-  implicit class LongOps(value: Long) {
-    def fromTokenAmountFormat: Double =
-      value / 10e7
-
-    def toTokenAmountFormat: Long =
-      (value * 10e7).toLong
-  }
-
-  implicit class DoubleOps(value: Double) {
-    def toTokenAmountFormat: Long =
-      (value * 10e7).toLong
-  }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/refined.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/refined.scala
@@ -1,0 +1,30 @@
+package org.amm_metagraph.shared_data
+
+import eu.timepit.refined.types.all.NonNegDouble
+import eu.timepit.refined.types.numeric.PosLong
+
+object refined {
+
+  implicit class PosLongOps(value: Long) {
+    def toPosLongUnsafe: PosLong =
+      PosLong.unsafeFrom(value)
+  }
+
+  implicit class LongOps(value: Long) {
+    def fromTokenAmountFormat: Double =
+      value / 10e7
+
+    def toTokenAmountFormat: Long =
+      (value * 10e7).toLong
+  }
+
+  implicit class DoubleOps(value: Double) {
+    def toTokenAmountFormat: Long =
+      (value * 10e7).toLong
+  }
+
+  implicit class NonNegDoubleOps(value: Double) {
+    def toNonNegDoubleUnsafe: NonNegDouble =
+      NonNegDouble.unsafeFrom(value)
+  }
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
@@ -1,6 +1,7 @@
 package org.amm_metagraph.shared_data.types
 
 import io.constellationnetwork.currency.dataApplication.DataUpdate
+import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap.{CurrencyId, SwapAmount}
@@ -9,8 +10,8 @@ import io.constellationnetwork.security.hash.Hash
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.types.numeric.PosLong
-import io.circe.refined._
-import org.amm_metagraph.shared_data.types.LiquidityPool._
+import org.amm_metagraph.shared_data.types.Governance.{RewardAllocationVoteOrdinal, RewardAllocationVoteReference}
+import org.amm_metagraph.shared_data.types.LiquidityPool.PoolId
 
 object DataUpdates {
   @derive(encoder, decoder)
@@ -50,4 +51,13 @@ object DataUpdates {
     minPrice: Option[PosLong],
     maxPrice: Option[PosLong]
   ) extends AmmUpdate
+
+  @derive(decoder, encoder)
+  case class RewardAllocationVoteUpdate(
+    address: Address,
+    parent: RewardAllocationVoteReference,
+    allocations: Seq[(String, PosLong)]
+  ) extends AmmUpdate {
+    val ordinal: RewardAllocationVoteOrdinal = parent.ordinal.next
+  }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
@@ -1,0 +1,153 @@
+package org.amm_metagraph.shared_data.types
+
+import java.time._
+
+import cats.Order
+import cats.effect.kernel.Async
+import cats.syntax.functor._
+import cats.syntax.semigroup._
+
+import io.constellationnetwork.ext.crypto._
+import io.constellationnetwork.ext.derevo.ordering
+import io.constellationnetwork.schema._
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.tokenLock.TokenLock
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher}
+
+import derevo.cats.order
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import enumeratum.values.{StringCirceEnum, StringEnum, StringEnumEntry}
+import eu.timepit.refined.auto.autoRefineV
+import eu.timepit.refined.cats._
+import eu.timepit.refined.types.numeric.{NonNegDouble, NonNegLong}
+import io.circe.refined._
+import io.circe.{Decoder, Encoder}
+import io.estatico.newtype.macros.newtype
+import org.amm_metagraph.shared_data.epochProgress.oneEpochProgressInSeconds
+import org.amm_metagraph.shared_data.types.DataUpdates.RewardAllocationVoteUpdate
+
+object Governance {
+  val maxCredits = 50.0
+
+  @newtype
+  @derive(order, encoder, decoder)
+  case class RewardAllocationVoteOrdinal(value: NonNegLong) {
+    def next: RewardAllocationVoteOrdinal = RewardAllocationVoteOrdinal(value |+| 1L)
+  }
+
+  object RewardAllocationVoteOrdinal {
+    val first: RewardAllocationVoteOrdinal = RewardAllocationVoteOrdinal(1L)
+
+    implicit val decoder: Decoder[RewardAllocationVoteOrdinal] = deriving
+    implicit val encoder: Encoder[RewardAllocationVoteOrdinal] = deriving
+    implicit val orderInstance: Order[RewardAllocationVoteOrdinal] = Order.by(_.value)
+  }
+
+  @derive(decoder, encoder, order, ordering)
+  case class RewardAllocationVoteReference(ordinal: RewardAllocationVoteOrdinal, hash: Hash)
+
+  object RewardAllocationVoteReference {
+    def of(hashedTransaction: Hashed[RewardAllocationVoteUpdate]): RewardAllocationVoteReference =
+      RewardAllocationVoteReference(hashedTransaction.ordinal, hashedTransaction.hash)
+
+    def of[F[_]: Async: Hasher](signedTransaction: Signed[RewardAllocationVoteUpdate]): F[RewardAllocationVoteReference] =
+      signedTransaction.value.hash.map(RewardAllocationVoteReference(signedTransaction.ordinal, _))
+
+    val empty: RewardAllocationVoteReference = RewardAllocationVoteReference(RewardAllocationVoteOrdinal(0L), Hash.empty)
+  }
+
+  @derive(encoder, decoder)
+  case class VotingWeightInfo(
+    weight: NonNegDouble,
+    tokenLock: TokenLock
+  )
+
+  @derive(encoder, decoder)
+  case class VotingWeight(
+    total: NonNegDouble,
+    info: List[VotingWeightInfo]
+  )
+
+  object VotingWeight {
+    def empty: VotingWeight = VotingWeight(NonNegDouble.MinValue, List.empty)
+  }
+
+  sealed abstract class AllocationCategory(val value: String) extends StringEnumEntry
+  object AllocationCategory extends StringEnum[AllocationCategory] with StringCirceEnum[AllocationCategory] {
+    val values = findValues
+
+    case object NodeOperator extends AllocationCategory("NodeOperator")
+    case object LiquidityPool extends AllocationCategory("LiquidityPool")
+
+    implicit val encoder: Encoder[AllocationCategory] = Encoder.encodeString.contramap(_.value)
+    implicit val decoder: Decoder[AllocationCategory] = Decoder.decodeString.emap { str =>
+      values.find(_.value == str).toRight(s"Invalid AllocationCategory value: $str")
+    }
+  }
+
+  @derive(encoder, decoder)
+  @newtype
+  case class AllocationId(value: String)
+
+  @derive(encoder, decoder)
+  case class Allocation(
+    id: AllocationId,
+    category: AllocationCategory,
+    weight: NonNegDouble
+  )
+
+  @derive(encoder, decoder)
+  case class AllocationEpochProgressInfo(
+    allocationGlobalEpochProgress: EpochProgress,
+    expireGlobalEpochProgress: EpochProgress,
+    monthReference: Int
+  )
+
+  object AllocationEpochProgressInfo {
+    def empty: AllocationEpochProgressInfo =
+      AllocationEpochProgressInfo(
+        EpochProgress.MinValue,
+        EpochProgress.MinValue,
+        Int.MinValue
+      )
+
+    def getAllocationEpochProgressInfo(
+      globalEpochProgress: EpochProgress
+    ): AllocationEpochProgressInfo = {
+      def getSecondsUntilMonthEnd: Long = {
+        val now = LocalDateTime.now(ZoneId.of("UTC"))
+        val lastDayOfMonth = YearMonth.now(ZoneId.of("UTC")).atEndOfMonth()
+        val monthEnd = LocalDateTime.of(lastDayOfMonth.getYear, lastDayOfMonth.getMonth, lastDayOfMonth.getDayOfMonth, 23, 59, 59)
+        val duration = Duration.between(now, monthEnd)
+        duration.getSeconds
+      }
+
+      val secondsUntilMonthEnd = getSecondsUntilMonthEnd
+      val epochProgressesUntilMonthEnd = secondsUntilMonthEnd / oneEpochProgressInSeconds
+      val expireGlobalEpochProgressValue = globalEpochProgress.value.value + epochProgressesUntilMonthEnd
+      val expireGlobalEpochProgress = EpochProgress(NonNegLong.unsafeFrom(expireGlobalEpochProgressValue))
+
+      AllocationEpochProgressInfo(
+        globalEpochProgress,
+        expireGlobalEpochProgress,
+        YearMonth.now(ZoneId.of("UTC")).getMonth.getValue
+      )
+    }
+  }
+
+  @derive(encoder, decoder)
+  case class UserAllocations(
+    credits: Double,
+    reference: RewardAllocationVoteReference,
+    allocationEpochProgressInfo: AllocationEpochProgressInfo,
+    allocations: List[Allocation]
+  )
+
+  object UserAllocations {
+    def empty: UserAllocations =
+      UserAllocations(maxCredits, RewardAllocationVoteReference.empty, AllocationEpochProgressInfo.empty, List.empty)
+  }
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/States.scala
@@ -5,14 +5,13 @@ import scala.collection.immutable.SortedSet
 import io.constellationnetwork.currency.dataApplication.{DataCalculatedState, DataOnChainState}
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SpendTransaction
-import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.security.signature.Signed
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import enumeratum.values.{StringCirceEnum, StringEnum, StringEnumEntry}
-import io.estatico.newtype.macros.newtype
 import org.amm_metagraph.shared_data.types.DataUpdates.AmmUpdate
+import org.amm_metagraph.shared_data.types.Governance._
 import org.amm_metagraph.shared_data.types.LiquidityPool.LiquidityPool
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress
 import org.amm_metagraph.shared_data.types.Swap.SwapCalculatedStateAddress
@@ -67,15 +66,12 @@ object States {
   }
 
   @derive(encoder, decoder)
-  @newtype
-  case class VotingWeight(value: Amount)
-
-  @derive(encoder, decoder)
   case class AmmCalculatedState(
     confirmedOperations: Map[OperationType, AmmOffChainState],
     pendingUpdates: Set[Signed[AmmUpdate]] = Set.empty[Signed[AmmUpdate]],
     spendTransactions: SortedSet[SpendTransaction] = SortedSet.empty[SpendTransaction],
-    votingWeights: Map[Address, VotingWeight] = Map.empty
+    votingWeights: Map[Address, VotingWeight] = Map.empty,
+    allocations: Map[Address, UserAllocations] = Map.empty
   ) extends DataCalculatedState
 
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -18,6 +18,30 @@ object Errors {
     def whenA(cond: Boolean): DataApplicationValidationType = if (cond) invalid else valid
   }
 
+  case object AllocationPercentageExceed extends DataApplicationValidationError {
+    val message = "Allocation percentage exceed"
+  }
+
+  case object NotSignedExclusivelyByAddressOwner extends DataApplicationValidationError {
+    val message = "Not signed exclusively by address owner"
+  }
+
+  case object ParentOrdinalLowerThenLastProcessedTxOrdinal extends DataApplicationValidationError {
+    val message = "Parent ordinal lower then last processed tx ordinal"
+  }
+
+  case object DailyAllocationExceed extends DataApplicationValidationError {
+    val message = "Daily allocation exceed"
+  }
+
+  case object HasNoMatchingParent extends DataApplicationValidationError {
+    val message = "Has no matching parent"
+  }
+
+  case object MissingVotingWeight extends DataApplicationValidationError {
+    val message = "Missing voting weight"
+  }
+
   case object StakingAmountShouldBeGreaterThanZero extends DataApplicationValidationError {
     val message = "Staking amount should be greater than zero (0)"
   }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/GovernanceValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/GovernanceValidations.scala
@@ -1,0 +1,101 @@
+package org.amm_metagraph.shared_data.validations
+
+import cats.effect.Async
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
+
+import org.amm_metagraph.shared_data.credits.getUpdatedCredits
+import org.amm_metagraph.shared_data.types.DataUpdates.RewardAllocationVoteUpdate
+import org.amm_metagraph.shared_data.types.Governance.{UserAllocations, VotingWeight, maxCredits}
+import org.amm_metagraph.shared_data.types.States._
+import org.amm_metagraph.shared_data.validations.Errors._
+import org.amm_metagraph.shared_data.validations.SharedValidations.isSignedExclusivelyByValidation
+
+object GovernanceValidations {
+  def rewardAllocationValidationsL1[F[_]: Async](
+    rewardAllocationVoteUpdate: RewardAllocationVoteUpdate
+  ): F[DataApplicationValidationErrorOr[Unit]] =
+    exceedingAllocationPercentage(rewardAllocationVoteUpdate).pure
+
+  def rewardAllocationValidationsL0[F[_]: Async](
+    rewardAllocationVoteUpdate: Signed[RewardAllocationVoteUpdate],
+    state: AmmCalculatedState,
+    lastSyncGlobalSnapshotEpochProgress: EpochProgress
+  )(implicit sp: SecurityProvider[F]): F[DataApplicationValidationErrorOr[Unit]] = {
+    val lastAllocations = state.allocations
+    val lastVotingWeights = state.votingWeights
+    val lastUserAllocation = lastAllocations.get(rewardAllocationVoteUpdate.address)
+
+    for {
+      isSignedExclusivelyBy <- isSignedExclusivelyByValidation(rewardAllocationVoteUpdate, rewardAllocationVoteUpdate.address)
+      lastTransactionRef = lastTransactionRefValidation(rewardAllocationVoteUpdate, lastUserAllocation)
+      dailyLimitAllocation = dailyLimitAllocationValidation(
+        lastUserAllocation,
+        lastSyncGlobalSnapshotEpochProgress
+      )
+      walletHasVotingWeight = walletHasVotingWeightValidation(
+        lastVotingWeights,
+        rewardAllocationVoteUpdate.address
+      )
+    } yield
+      isSignedExclusivelyBy
+        .productR(lastTransactionRef)
+        .productR(dailyLimitAllocation)
+        .productR(walletHasVotingWeight)
+  }
+
+  private def exceedingAllocationPercentage(
+    rewardAllocationVoteUpdate: RewardAllocationVoteUpdate
+  ): DataApplicationValidationErrorOr[Unit] = {
+    val allocationsSum = rewardAllocationVoteUpdate.allocations.map {
+      case (_, allocationWeight) => allocationWeight.value
+    }.sum
+
+    val allocationsWeightsNormalized = rewardAllocationVoteUpdate.allocations.map {
+      case (_, allocationWeight) => (allocationWeight.value / allocationsSum).toDouble
+    }
+
+    AllocationPercentageExceed.whenA(allocationsWeightsNormalized.sum > 1.0)
+  }
+
+  private def lastTransactionRefValidation(
+    rewardAllocationVoteUpdate: Signed[RewardAllocationVoteUpdate],
+    lastUserAllocation: Option[UserAllocations]
+  ): DataApplicationValidationErrorOr[Unit] = lastUserAllocation match {
+    case None => valid
+    case Some(value) =>
+      val reference = value.reference
+
+      if (rewardAllocationVoteUpdate.parent.ordinal < reference.ordinal)
+        ParentOrdinalLowerThenLastProcessedTxOrdinal.invalid
+      else {
+        HasNoMatchingParent.unlessA(
+          rewardAllocationVoteUpdate.parent.ordinal === reference.ordinal && rewardAllocationVoteUpdate.parent.hash === reference.hash
+        )
+      }
+  }
+
+  private def dailyLimitAllocationValidation(
+    lastUserAllocation: Option[UserAllocations],
+    lastCurrencySnapshotEpochProgress: EpochProgress
+  ): DataApplicationValidationErrorOr[Unit] =
+    lastUserAllocation.fold(valid) { allocation =>
+      getUpdatedCredits(
+        allocation.allocationEpochProgressInfo.allocationGlobalEpochProgress.value.value,
+        allocation.credits,
+        lastCurrencySnapshotEpochProgress.value.value,
+        maxCredits
+      ).fold(_ => DailyAllocationExceed.invalid, _ => valid)
+    }
+
+  private def walletHasVotingWeightValidation(
+    lastVotingWeights: Map[Address, VotingWeight],
+    address: Address
+  ): DataApplicationValidationErrorOr[Unit] =
+    MissingVotingWeight.unlessA(lastVotingWeights.get(address).exists(_.total.value > 0.0d))
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
@@ -5,9 +5,8 @@ import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
-import org.amm_metagraph.shared_data.Utils.buildLiquidityPoolUniqueIdentifier
 import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, getLiquidityPools}
+import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, buildLiquidityPoolUniqueIdentifier, getLiquidityPools}
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 import org.amm_metagraph.shared_data.validations.Errors.{LiquidityPoolAlreadyExists, LiquidityPoolNotEnoughInformation}
 import org.amm_metagraph.shared_data.validations.SharedValidations.validateIfAllowSpendsAndSpendTransactionsAreDuplicated

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
@@ -1,16 +1,32 @@
 package org.amm_metagraph.shared_data.validations
 
+import cats.effect.Async
+import cats.syntax.all._
+
 import scala.collection.immutable.SortedSet
 
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SpendTransaction
+import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops.PublicKeyOps
 import io.constellationnetwork.security.signature.Signed
 
 import org.amm_metagraph.shared_data.types.DataUpdates._
-import org.amm_metagraph.shared_data.validations.Errors.DuplicatedOperation
+import org.amm_metagraph.shared_data.validations.Errors._
 
 object SharedValidations {
+  def isSignedExclusivelyByValidation[F[_]: Async: SecurityProvider, A](
+    signed: Signed[A],
+    signerAddress: Address
+  ): F[DataApplicationValidationErrorOr[Unit]] =
+    signed.proofs.existsM { proof =>
+      proof.id.hex.toPublicKey.map { signerPk =>
+        signerPk.toAddress =!= signerAddress
+      }
+    }.map(isNotSignedExclusively => NotSignedExclusivelyByAddressOwner.whenA(isNotSignedExclusively))
+
   def validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
     allowSpendRef: Hash,
     existingPendingUpdates: Set[Signed[AmmUpdate]],
@@ -21,6 +37,7 @@ object SharedValidations {
       case stakingUpdate: StakingUpdate =>
         stakingUpdate.tokenAAllowSpend == allowSpendRef || stakingUpdate.tokenBAllowSpend == allowSpendRef
       case swapUpdate: SwapUpdate => swapUpdate.allowSpendReference == allowSpendRef
+      case _                      => false
     })
 
     val spendTransactionAlreadyExists = existingSpendTransactions.exists(t => t.allowSpendRef.contains(allowSpendRef))

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SwapValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SwapValidations.scala
@@ -5,9 +5,8 @@ import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
-import org.amm_metagraph.shared_data.Utils.buildLiquidityPoolUniqueIdentifier
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, getLiquidityPools}
+import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, buildLiquidityPoolUniqueIdentifier, getLiquidityPools}
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 import org.amm_metagraph.shared_data.validations.Errors._
 import org.amm_metagraph.shared_data.validations.SharedValidations.validateIfAllowSpendsAndSpendTransactionsAreDuplicated

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
@@ -1,6 +1,6 @@
 package org.amm_metagraph.shared_data.validations
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, OptionT}
 import cats.effect.kernel.Async
 import cats.syntax.all._
 
@@ -11,6 +11,7 @@ import io.constellationnetwork.security.{Hasher, SecurityProvider}
 
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.States._
+import org.amm_metagraph.shared_data.validations.GovernanceValidations.{rewardAllocationValidationsL0, rewardAllocationValidationsL1}
 import org.amm_metagraph.shared_data.validations.LiquidityPoolValidations.{liquidityPoolValidationsL0, liquidityPoolValidationsL1}
 import org.amm_metagraph.shared_data.validations.StakingValidations.{stakingValidationsL0, stakingValidationsL1}
 import org.amm_metagraph.shared_data.validations.SwapValidations.{swapValidationsL0, swapValidationsL1}
@@ -30,19 +31,32 @@ object ValidationService {
   def make[F[_]: Async: SecurityProvider: Hasher]: F[ValidationService[F]] = Async[F].delay {
     new ValidationService[F] {
       private def validateL1(update: AmmUpdate): F[DataApplicationValidationErrorOr[Unit]] = update match {
-        case stakingUpdate: StakingUpdate             => stakingValidationsL1(stakingUpdate)
-        case liquidityPoolUpdate: LiquidityPoolUpdate => liquidityPoolValidationsL1(liquidityPoolUpdate)
-        case swapUpdate: SwapUpdate                   => swapValidationsL1(swapUpdate)
+        case stakingUpdate: StakingUpdate                           => stakingValidationsL1(stakingUpdate)
+        case liquidityPoolUpdate: LiquidityPoolUpdate               => liquidityPoolValidationsL1(liquidityPoolUpdate)
+        case swapUpdate: SwapUpdate                                 => swapValidationsL1(swapUpdate)
+        case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate => rewardAllocationValidationsL1(rewardAllocationVoteUpdate)
       }
 
       private def validateL0(
         signedUpdate: Signed[AmmUpdate],
         state: AmmCalculatedState
-      )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] = signedUpdate.value match {
-        case stakingUpdate: StakingUpdate             => stakingValidationsL0(stakingUpdate, state, signedUpdate.proofs)
-        case liquidityPoolUpdate: LiquidityPoolUpdate => liquidityPoolValidationsL0(liquidityPoolUpdate, state)
-        case swapUpdate: SwapUpdate                   => swapValidationsL0(swapUpdate, state)
-      }
+      )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
+        for {
+          lastSyncGlobalSnapshot <- OptionT(context.getLastSynchronizedGlobalSnapshot).getOrRaise(
+            new IllegalStateException("lastSyncGlobalSnapshot unavailable")
+          )
+          result <- signedUpdate.value match {
+            case stakingUpdate: StakingUpdate             => stakingValidationsL0(Signed(stakingUpdate, signedUpdate.proofs), state)
+            case liquidityPoolUpdate: LiquidityPoolUpdate => liquidityPoolValidationsL0(liquidityPoolUpdate, state)
+            case swapUpdate: SwapUpdate                   => swapValidationsL0(swapUpdate, state)
+            case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate =>
+              rewardAllocationValidationsL0(
+                Signed(rewardAllocationVoteUpdate, signedUpdate.proofs),
+                state,
+                lastSyncGlobalSnapshot.epochProgress
+              )
+          }
+        } yield result
 
       override def validateUpdate(
         update: AmmUpdate

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -22,9 +22,10 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
-import org.amm_metagraph.shared_data.Utils.{LongOps, buildLiquidityPoolUniqueIdentifier}
 import org.amm_metagraph.shared_data.combiners.LiquidityPoolCombiner.combineLiquidityPool
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates._
+import org.amm_metagraph.shared_data.types.LiquidityPool.buildLiquidityPoolUniqueIdentifier
 import org.amm_metagraph.shared_data.types.States._
 import weaver.MutableIOSuite
 

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
@@ -24,8 +24,8 @@ import io.constellationnetwork.security.signature.signature.{Signature, Signatur
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
-import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.combiners.StakingCombiner.combineStaking
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -24,8 +24,8 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
-import org.amm_metagraph.shared_data.Utils._
 import org.amm_metagraph.shared_data.combiners.SwapCombiner.combineSwap
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
@@ -24,7 +24,7 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
-import org.amm_metagraph.shared_data.Utils.{DoubleOps, LongOps}
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -26,7 +26,7 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
-import org.amm_metagraph.shared_data.Utils.{DoubleOps, LongOps, PosLongOps}
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.Staking.StakingCalculatedStateAddress

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/SwapValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/SwapValidationTest.scala
@@ -25,7 +25,7 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.PosLong
-import org.amm_metagraph.shared_data.Utils.{DoubleOps, LongOps, PosLongOps}
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._


### PR DESCRIPTION
### Changes
* Introduced the voting allocation system to manage and update voting allocations based on user weights.
* Added a new update type: RewardAllocationVoteUpdate. Updates should be sent in the following format:
```json
{
    "value": {
        "RewardAllocationVoteUpdate": {
            "address": "DAG5kq5J6gudAbyGsgqPReGz8ZDRM94UoPwCFSem",
            "allocations": [
                [
                    "key1",
                    10
                ],
                [
                    "key2",
                    20
                ],
                [
                    "key3",
                    30
                ]
            ],
            "parent": {
                "hash": "0000000000000000000000000000000000000000000000000000000000000000",
                "ordinal": 0
            }
        }
    },
    "proofs": [
        {
            "id": "6b8d13e6eea6b072b3963982be33e09a7a6a10d5731f1805d13e7b6993f51c364ae7e72b9499358e4e0deace26c15507be39643593b64ffac337a8c35c059335",
            "signature": "304502210083849fc99a246e7ed428122b8e700a16eabc0ddf9271775208529a9b5385b74602203b612b4a9e603d3ac78e463844e3d441eda3e2cb294b9570530b1dd2edcb404d"
        }
    ]
}
```
* These updates calculate the voting weight of a user and distribute votes based on the allocations provided.   
* Fixed the voting weight calculation to account for the lock period during weight computation.
* Added a new endpoint to retrieve voting information.

### Notes
* Edge Cases: Further discussion is required for scenarios where locks expire mid-month.