### PR TITLE
feat: adding lp shares and unit tests

### DIFF
--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
@@ -54,12 +54,15 @@ object DummyL0Context {
     gsEpochProgress: EpochProgress = EpochProgress.MinValue
   ): L0NodeContext[F] =
     new L0NodeContext[F] {
-      def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
-      def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = ???
       def getLastCurrencySnapshot: F[Option[Hashed[CurrencyIncrementalSnapshot]]] = ???
       def getCurrencySnapshot(ordinal: SnapshotOrdinal): F[Option[Hashed[CurrencyIncrementalSnapshot]]] = ???
       def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]] = ???
       def securityProvider: SecurityProvider[F] = ???
-      def getCurrencyId: F[CurrencyId] = ???
+      def getCurrencyId: F[CurrencyId] = CurrencyId(metagraphAddress).pure[F]
+      def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
+      def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = for {
+        globalIncrementalSnapshot <- buildGlobalIncrementalSnapshot[F](keyPair, gsEpochProgress)
+        globalSnapshotInfo = buildGlobalSnapshotInfo(allowSpends)
+      } yield Some((globalIncrementalSnapshot, globalSnapshotInfo))
     }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -59,6 +59,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         )
       )
     )
+
   test("Successfully create a liquidity pool") { implicit res =>
     implicit val (h, sp) = res
 
@@ -136,7 +137,10 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         expect.eql(tokenAId.get, updatedLiquidityPool.tokenA.identifier.get) &&
         expect.eql(50L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
         expect.eql(tokenBId.get, updatedLiquidityPool.tokenB.identifier.get) &&
-        expect.eql(5000d, updatedLiquidityPool.k)
+        expect.eql(5000d, updatedLiquidityPool.k) &&
+        expect.eql(1.toTokenAmountFormat, updatedLiquidityPool.poolShares.totalShares.value) &&
+        expect.eql(1, updatedLiquidityPool.poolShares.addressShares.size) &&
+        expect.eql(1.toTokenAmountFormat, updatedLiquidityPool.poolShares.addressShares(ownerAddress).value.value.value)
   }
 
   test("Successfully create a liquidity pool - L0Token - DAG") { implicit res =>
@@ -217,6 +221,9 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         expect.eql(tokenAId.get, updatedLiquidityPool.tokenA.identifier.get) &&
         expect.eql(50L.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
         expect.eql(tokenBId.isEmpty, updatedLiquidityPool.tokenB.identifier.isEmpty) &&
-        expect.eql(5000d, updatedLiquidityPool.k)
+        expect.eql(5000d, updatedLiquidityPool.k) &&
+        expect.eql(1.toTokenAmountFormat, updatedLiquidityPool.poolShares.totalShares.value) &&
+        expect.eql(1, updatedLiquidityPool.poolShares.addressShares.size) &&
+        expect.eql(1.toTokenAmountFormat, updatedLiquidityPool.poolShares.addressShares(ownerAddress).value.value.value)
   }
 }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -12,6 +12,7 @@ import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.SpendTransaction
+import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.schema.{SnapshotOrdinal, artifact}
@@ -54,8 +55,7 @@ object SwapCombinerTest extends MutableIOSuite {
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
-      LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
+      PoolShares(1.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
     )
     (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }
@@ -162,15 +162,15 @@ object SwapCombinerTest extends MutableIOSuite {
           case transaction: SpendTransaction => transaction
         }
 
-      spendTransaction = swapSpendTransactions.find(_.allowSpendRef.get === signedAllowSpend.hash)
+      spendTransaction = swapSpendTransactions.find(_.allowSpendRef.exists(_ === signedAllowSpend.hash))
     } yield
       expect.eql(1100000L, addressSwapResponse.fromToken.amount.value.fromTokenAmountFormat) &&
         expect.eql(primaryToken.identifier.get, addressSwapResponse.fromToken.identifier.get) &&
-        expect.eql(1823154.05651777, addressSwapResponse.toToken.amount.value.fromTokenAmountFormat) &&
+        expect.eql(1818181.81818181, addressSwapResponse.toToken.amount.value.fromTokenAmountFormat) &&
         expect.eql(1000000L.toTokenAmountFormat, oldLiquidityPool.tokenA.amount.value) &&
         expect.eql(2000000L.toTokenAmountFormat, oldLiquidityPool.tokenB.amount.value) &&
         expect.eql(1100000L.toTokenAmountFormat, updatedLiquidityPool.tokenA.amount.value) &&
-        expect.eql(1823154.05651777.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
+        expect.eql(1818181.81818181.toTokenAmountFormat, updatedLiquidityPool.tokenB.amount.value) &&
         expect.eql(allowSpend.amount.value.value, spendTransaction.get.amount.value.value)
   }
 

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.security.hash.Hash
@@ -24,6 +25,7 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.PosLong
 import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool._
@@ -54,8 +56,7 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
-      LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
+      PoolShares(1L.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
     )
     (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -15,6 +15,7 @@ import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.security.hash.Hash
@@ -51,14 +52,14 @@ object StakingValidationTest extends MutableIOSuite {
     val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
     val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
     val poolId = org.amm_metagraph.shared_data.types.LiquidityPool.PoolId(s"$primaryAddressAsString-$pairAddressAsString")
+
     val liquidityPool = LiquidityPool(
       poolId,
       tokenA,
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
-      LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
+      PoolShares(1.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
     )
     (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/SwapValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/SwapValidationTest.scala
@@ -14,6 +14,7 @@ import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.JsonSerializer
 import io.constellationnetwork.schema.ID.Id
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.security.hash.Hash
@@ -55,8 +56,7 @@ object SwapValidationTest extends MutableIOSuite {
       tokenB,
       owner,
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
-      math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat,
-      LiquidityProviders(Map(owner -> math.sqrt(tokenA.amount.value.toDouble * tokenB.amount.value.toDouble).toTokenAmountFormat))
+      PoolShares(1.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
     )
     (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
   }


### PR DESCRIPTION
### Changes
+ Adding the LP total and address shares
+ The calculation and the logic were defined on JIRA ticket: https://constellationnetwork.atlassian.net/browse/PROT-944
+ Added unit tests and changed the current ones to cover this new feature

### Tests
+ You can run the unit tests and check the output of combiners in Stake and LiquidityPool