### PR TITLE
feat: adding failed operations per data update on state

### DIFF
--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/custom_routes/CustomRoutes.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/custom_routes/CustomRoutes.scala
@@ -94,7 +94,7 @@ case class CustomRoutes[F[_]: Async](calculatedStateService: CalculatedStateServ
         .find(_.value.allowSpendReference === allowSpendHash)
         .map(buildPendingSwapResponse)
         .orElse {
-          swapCalculatedState.confirmed.values.flatten
+          swapCalculatedState.confirmed.value.values.flatten
             .find(_.allowSpendReference === allowSpendHash)
             .map(buildConfirmedSwapResponse)
         }

--- a/modules/shared_data/src/main/resources/application.conf
+++ b/modules/shared_data/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 environment = "prod"
 node-validators-governance-allocation-id = "NodeValidators"
+failed-operations-expiration-epoch-progresses = 30
 governance {
     voting-weight-multipliers {
        lock-for-six-months-multiplier = 0.25

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfig.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfig.scala
@@ -1,8 +1,11 @@
 package org.amm_metagraph.shared_data.app
 
+import io.constellationnetwork.schema.epoch.EpochProgress
+
 import eu.timepit.refined.types.numeric.PosDouble
 
 case class ApplicationConfig(
+  failedOperationsExpirationEpochProgresses: EpochProgress,
   nodeValidatorsGovernanceAllocationId: String,
   environment: ApplicationConfig.Environment,
   governance: ApplicationConfig.Governance

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfigOps.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfigOps.scala
@@ -2,8 +2,10 @@ package org.amm_metagraph.shared_data.app
 
 import cats.effect.kernel.Sync
 
-import eu.timepit.refined.api.RefType
-import eu.timepit.refined.types.numeric.PosDouble
+import io.constellationnetwork.schema.epoch.EpochProgress
+
+import eu.timepit.refined.pureconfig._
+import eu.timepit.refined.types.numeric.NonNegLong
 import org.amm_metagraph.shared_data.app.ApplicationConfig._
 import pureconfig._
 import pureconfig.error.CannotConvert
@@ -19,12 +21,8 @@ object ApplicationConfigOps {
 }
 
 object ConfigReaders {
-  implicit val posDoubleReader: ConfigReader[PosDouble] = ConfigReader.fromString[PosDouble] { str =>
-    RefType.applyRef[PosDouble](str.toDouble) match {
-      case Right(value) => Right(value)
-      case Left(error)  => Left(CannotConvert(str, "PosDouble", error))
-    }
-  }
+  implicit val epochProgressReader: ConfigReader[EpochProgress] = ConfigReader[NonNegLong].map(EpochProgress(_))
+
   implicit val votingWeightMultipliersConfigReader: ConfigReader[ApplicationConfig.VotingWeightMultipliers] = deriveReader
   implicit val governanceConfigReader: ConfigReader[ApplicationConfig.Governance] = deriveReader
   implicit val configReader: ConfigReader[Environment] = ConfigReader.fromString[Environment] {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedState.scala
@@ -1,7 +1,5 @@
 package org.amm_metagraph.shared_data.calculated_state
 
-import scala.collection.immutable.SortedSet
-
 import io.constellationnetwork.schema.SnapshotOrdinal
 
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
@@ -10,5 +8,5 @@ case class CalculatedState(ordinal: SnapshotOrdinal, state: AmmCalculatedState)
 
 object CalculatedState {
   def empty: CalculatedState =
-    CalculatedState(SnapshotOrdinal.MinValue, AmmCalculatedState(Map.empty, Set.empty, SortedSet.empty))
+    CalculatedState(SnapshotOrdinal.MinValue, AmmCalculatedState())
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/calculated_state/CalculatedStateService.scala
@@ -37,12 +37,11 @@ object CalculatedStateService {
         ): F[Boolean] =
           stateRef.modify { currentState =>
             val currentCalculatedState = currentState.state
-            val updatedOperations = state.confirmedOperations.foldLeft(currentCalculatedState.confirmedOperations) {
+            val updatedOperations = state.operations.foldLeft(currentCalculatedState.operations) {
               case (acc, (address, value)) =>
                 acc.updated(address, value)
             }
 
-            val updatedPendingUpdates = currentCalculatedState.pendingUpdates ++ state.pendingUpdates
             val updatedSpendTransactions = currentCalculatedState.spendTransactions ++ state.spendTransactions
 
             (
@@ -50,7 +49,6 @@ object CalculatedStateService {
                 snapshotOrdinal,
                 AmmCalculatedState(
                   updatedOperations,
-                  updatedPendingUpdates,
                   updatedSpendTransactions,
                   state.votingWeights,
                   state.allocations

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/CombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/CombinerService.scala
@@ -63,7 +63,10 @@ object CombinerService {
               oldState.calculated
             )
 
-          pendingUpdates = oldState.calculated.pendingUpdates
+          pendingUpdates: Set[Signed[AmmUpdate]] = oldState.calculated.operations.values
+            .flatMap(_.pending)
+            .toSet
+
           updates = incomingUpdates ++ pendingUpdates
 
           updatedVotingWeights = updateVotingWeights(
@@ -94,11 +97,24 @@ object CombinerService {
                     combinedState <- signedUpdate.value match {
                       case stakingUpdate: StakingUpdate =>
                         logger.info(s"Received staking update: $stakingUpdate") >>
-                          combineStaking(acc, Signed(stakingUpdate, signedUpdate.proofs), address, currentSnapshotOrdinal)
+                          combineStaking(
+                            applicationConfig,
+                            acc,
+                            Signed(stakingUpdate, signedUpdate.proofs),
+                            address,
+                            currentSnapshotOrdinal,
+                            lastSyncGlobalEpochProgress
+                          )
 
                       case liquidityPoolUpdate: LiquidityPoolUpdate =>
                         logger.info(s"Received liquidity pool update: $liquidityPoolUpdate") >>
-                          combineLiquidityPool(acc, Signed(liquidityPoolUpdate, signedUpdate.proofs), address)
+                          combineLiquidityPool(
+                            applicationConfig,
+                            acc,
+                            Signed(liquidityPoolUpdate, signedUpdate.proofs),
+                            address,
+                            lastSyncGlobalEpochProgress
+                          )
 
                       case swapUpdate: SwapUpdate =>
                         logger.info(s"Received swap update: $swapUpdate") >>

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/GovernanceCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/GovernanceCombiner.scala
@@ -102,7 +102,7 @@ object GovernanceCombiner {
   ): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
     def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("GovernanceCombiner")
 
-    val liquidityPools = getLiquidityPoolCalculatedState(acc.calculated).liquidityPools
+    val liquidityPools = getLiquidityPoolCalculatedState(acc.calculated).confirmed.value
 
     RewardAllocationVoteReference.of(signedRewardAllocationVoteUpdate).flatMap { reference =>
       val allocationsSum = signedRewardAllocationVoteUpdate.allocations.map { case (_, weight) => weight.value }.sum

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/StakingCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/StakingCombiner.scala
@@ -10,6 +10,7 @@ import io.constellationnetwork.schema.SnapshotOrdinal
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact._
 import io.constellationnetwork.schema.balance.Amount
+import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap.AllowSpend
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher}
@@ -17,6 +18,7 @@ import io.constellationnetwork.security.{Hashed, Hasher}
 import eu.timepit.refined.types.numeric.NonNegLong
 import monocle.syntax.all._
 import org.amm_metagraph.shared_data.SpendTransactions.generateSpendAction
+import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.globalSnapshots.{getAllowSpendLastSyncGlobalSnapshotState, getLastSyncGlobalIncrementalSnapshot}
 import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
@@ -46,19 +48,20 @@ object StakingCombiner {
       (liquidityPool.tokenB, liquidityPool.tokenA)
     }
 
-    val currentPrimaryTokenAmount = primaryToken.amount.value.fromTokenAmountFormat
-    val currentPairTokenAmount = pairToken.amount.value.fromTokenAmountFormat
+    val currentPrimaryTokenAmount = primaryToken.amount.value
+    val currentPairTokenAmount = pairToken.amount.value
 
     val incomingPrimaryAmount = stakingUpdate.tokenAAmount.value
-    val incomingPairAmount = (incomingPrimaryAmount * currentPairTokenAmount) / currentPrimaryTokenAmount // Maintain invariant
+    val incomingPairAmount =
+      (BigDecimal(incomingPrimaryAmount) * BigDecimal(currentPairTokenAmount)) / BigDecimal(currentPrimaryTokenAmount) // Maintain invariant
 
     val relativeDepositIncrease = incomingPrimaryAmount.toDouble / (currentPrimaryTokenAmount + incomingPrimaryAmount)
-    val newlyIssuedShares = relativeDepositIncrease * liquidityPool.poolShares.totalShares.value.fromTokenAmountFormat
+    val newlyIssuedShares = relativeDepositIncrease * liquidityPool.poolShares.totalShares.value
 
     UpdatedTokenInformation(
-      primaryToken.copy(amount = incomingPrimaryAmount.toTokenAmountFormat.toPosLongUnsafe),
-      pairToken.copy(amount = incomingPairAmount.toTokenAmountFormat.toPosLongUnsafe),
-      newlyIssuedShares.toTokenAmountFormat
+      primaryToken.copy(amount = incomingPrimaryAmount.toPosLongUnsafe),
+      pairToken.copy(amount = incomingPairAmount.toLong.toPosLongUnsafe),
+      newlyIssuedShares.toLong
     )
   }
 
@@ -105,15 +108,15 @@ object StakingCombiner {
   }
 
   def combineStaking[F[_]: Async: Hasher](
+    applicationConfig: ApplicationConfig,
     acc: DataState[AmmOnChainState, AmmCalculatedState],
     signedStakingUpdate: Signed[StakingUpdate],
     signerAddress: Address,
-    currentSnapshotOrdinal: SnapshotOrdinal
+    currentSnapshotOrdinal: SnapshotOrdinal,
+    lastSyncGlobalEpochProgress: EpochProgress
   )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
     val stakingUpdate = signedStakingUpdate.value
-
-    val confirmedStaking = getStakingCalculatedState(acc.calculated).confirmed
-
+    val stakingCalculatedState = getStakingCalculatedState(acc.calculated)
     val updates = stakingUpdate :: acc.onChain.updates
 
     (
@@ -126,19 +129,20 @@ object StakingCombiner {
           gsEpochProgress = lastSyncHashedGIS.epochProgress
           updatedPendingCalculatedState =
             if (stakingUpdate.maxValidGsEpochProgress < gsEpochProgress) {
-              acc.calculated.pendingUpdates - signedStakingUpdate
-            } else if (!acc.calculated.pendingUpdates.contains(signedStakingUpdate)) {
-              acc.calculated.pendingUpdates + signedStakingUpdate
+              stakingCalculatedState.pending - signedStakingUpdate
+            } else if (!stakingCalculatedState.pending.contains(signedStakingUpdate)) {
+              stakingCalculatedState.pending + signedStakingUpdate
             } else {
-              acc.calculated.pendingUpdates
+              stakingCalculatedState.pending
             }
 
-          newStakingState = StakingCalculatedState(confirmedStaking)
-          updatedCalculatedState = acc.calculated
-            .focus(_.confirmedOperations)
-            .modify(_.updated(OperationType.Staking, newStakingState))
-            .focus(_.pendingUpdates)
+          newStakingState = stakingCalculatedState
+            .focus(_.pending)
             .replace(updatedPendingCalculatedState)
+
+          updatedCalculatedState = acc.calculated
+            .focus(_.operations)
+            .modify(_.updated(OperationType.Staking, newStakingState))
 
         } yield
           DataState(
@@ -147,9 +151,9 @@ object StakingCombiner {
           )
 
       case (Some(_), Some(_)) =>
-        val liquidityPoolsCalculatedState = getLiquidityPools(acc.calculated)
+        val liquidityPoolsCalculatedState = getLiquidityPoolCalculatedState(acc.calculated)
 
-        val maybeLastStakingInfo = confirmedStaking.get(signerAddress) match {
+        val maybeLastStakingInfo = stakingCalculatedState.confirmed.value.get(signerAddress) match {
           case Some(stakingState: StakingCalculatedStateAddress) =>
             StakingCalculatedStateLastReference(
               stakingState.tokenAAllowSpend,
@@ -163,38 +167,6 @@ object StakingCombiner {
         }
 
         for {
-          poolId <- buildLiquidityPoolUniqueIdentifier(stakingUpdate.tokenAId, stakingUpdate.tokenBId)
-          liquidityPool <- getLiquidityPoolByPoolId(liquidityPoolsCalculatedState, poolId)
-          updatedTokenInformation = getUpdatedTokenInformation(stakingUpdate, liquidityPool)
-          liquidityPoolUpdated = updateLiquidityPool(liquidityPool, signerAddress, updatedTokenInformation)
-
-          stakingCalculatedStateAddress = StakingCalculatedStateAddress(
-            stakingUpdate.tokenAAllowSpend,
-            stakingUpdate.tokenBAllowSpend,
-            updatedTokenInformation.primaryTokenInformation,
-            updatedTokenInformation.pairTokenInformation,
-            currentSnapshotOrdinal,
-            maybeLastStakingInfo
-          )
-
-          updatedPendingCalculatedState = acc.calculated.pendingUpdates - signedStakingUpdate
-          updatedStakingCalculatedState = StakingCalculatedState(
-            confirmedStaking.updatedWith(signerAddress) {
-              case Some(confirmedSwaps) => Some(confirmedSwaps + stakingCalculatedStateAddress)
-              case None                 => Some(Set(stakingCalculatedStateAddress))
-            }
-          )
-
-          updatedLiquidityPool = LiquidityPoolCalculatedState(liquidityPoolsCalculatedState.updated(poolId.value, liquidityPoolUpdated))
-
-          updatedCalculatedState = acc.calculated
-            .focus(_.confirmedOperations)
-            .modify(_.updated(OperationType.Staking, updatedStakingCalculatedState))
-            .focus(_.confirmedOperations)
-            .modify(_.updated(OperationType.LiquidityPool, updatedLiquidityPool))
-            .focus(_.pendingUpdates)
-            .replace(updatedPendingCalculatedState)
-
           allowSpendTokenA <- getAllowSpendLastSyncGlobalSnapshotState(
             stakingUpdate.tokenAAllowSpend
           )
@@ -203,14 +175,127 @@ object StakingCombiner {
             stakingUpdate.tokenBAllowSpend
           )
 
-          spendTransactions = generateSpendTransactions(allowSpendTokenA.get, allowSpendTokenB.get)
-
-        } yield
-          DataState(
-            AmmOnChainState(updates),
-            updatedCalculatedState,
-            spendTransactions
+          poolId <- buildLiquidityPoolUniqueIdentifier(stakingUpdate.tokenAId, stakingUpdate.tokenBId)
+          liquidityPool <- getLiquidityPoolByPoolId(liquidityPoolsCalculatedState.confirmed.value, poolId)
+          updatedTokenInformation = getUpdatedTokenInformation(stakingUpdate, liquidityPool)
+          maybeFailedUpdate = validateUpdate(
+            applicationConfig,
+            signedStakingUpdate,
+            updatedTokenInformation,
+            allowSpendTokenA.get,
+            allowSpendTokenB.get,
+            lastSyncGlobalEpochProgress
           )
+          response = maybeFailedUpdate match {
+            case Some(failedCalculatedState) =>
+              val updatedStakingCalculatedState = stakingCalculatedState
+                .focus(_.failed)
+                .modify(_ + failedCalculatedState)
+              val updatedCalculatedState = acc.calculated
+                .focus(_.operations)
+                .modify(_.updated(OperationType.Staking, updatedStakingCalculatedState))
+
+              DataState(
+                AmmOnChainState(updates),
+                updatedCalculatedState
+              )
+
+            case None =>
+              val liquidityPoolUpdated = updateLiquidityPool(liquidityPool, signerAddress, updatedTokenInformation)
+              val stakingCalculatedStateAddress =
+                StakingCalculatedStateAddress(
+                  stakingUpdate.tokenAAllowSpend,
+                  stakingUpdate.tokenBAllowSpend,
+                  updatedTokenInformation.primaryTokenInformation,
+                  updatedTokenInformation.pairTokenInformation,
+                  currentSnapshotOrdinal,
+                  maybeLastStakingInfo
+                )
+
+              val updatedPendingCalculatedState = stakingCalculatedState.pending - signedStakingUpdate
+
+              val updatedStakingCalculatedState =
+                stakingCalculatedState
+                  .focus(_.confirmed.value)
+                  .modify(current =>
+                    current.updatedWith(signerAddress) {
+                      case Some(confirmedSwaps) => Some(confirmedSwaps + stakingCalculatedStateAddress)
+                      case None                 => Some(Set(stakingCalculatedStateAddress))
+                    }
+                  )
+                  .focus(_.pending)
+                  .replace(updatedPendingCalculatedState)
+
+              val updatedLiquidityPool = liquidityPoolsCalculatedState
+                .focus(_.confirmed.value)
+                .modify(_.updated(poolId.value, liquidityPoolUpdated))
+
+              val updatedCalculatedState = acc.calculated
+                .focus(_.operations)
+                .modify(_.updated(OperationType.Staking, updatedStakingCalculatedState))
+                .focus(_.operations)
+                .modify(_.updated(OperationType.LiquidityPool, updatedLiquidityPool))
+
+              val spendTransactions = generateSpendTransactions(allowSpendTokenA.get, allowSpendTokenB.get)
+
+              DataState(
+                AmmOnChainState(updates),
+                updatedCalculatedState,
+                spendTransactions
+              )
+          }
+        } yield response
+    }
+  }
+
+  def validateUpdate(
+    applicationConfig: ApplicationConfig,
+    signedUpdate: Signed[StakingUpdate],
+    tokenInformation: UpdatedTokenInformation,
+    allowSpendTokenA: Hashed[AllowSpend],
+    allowSpendTokenB: Hashed[AllowSpend],
+    lastSyncGlobalEpochProgress: EpochProgress
+  ): Option[FailedCalculatedState] = {
+    val (tokenA, tokenB) = if (tokenInformation.primaryTokenInformation.identifier == allowSpendTokenA.currency) {
+      (tokenInformation.primaryTokenInformation, tokenInformation.pairTokenInformation)
+    } else {
+      (tokenInformation.pairTokenInformation, tokenInformation.primaryTokenInformation)
+    }
+
+    if (tokenA.amount.value > allowSpendTokenA.amount.value.value) {
+      FailedCalculatedState(
+        AmountGreaterThanAllowSpendLimit(allowSpendTokenA.signed.value),
+        EpochProgress(
+          NonNegLong.unsafeFrom(
+            lastSyncGlobalEpochProgress.value.value + applicationConfig.failedOperationsExpirationEpochProgresses.value.value
+          )
+        ),
+        signedUpdate
+      ).some
+    } else if (tokenB.amount.value > allowSpendTokenB.amount.value.value) {
+      FailedCalculatedState(
+        AmountGreaterThanAllowSpendLimit(allowSpendTokenB.signed.value),
+        EpochProgress(
+          NonNegLong.unsafeFrom(
+            lastSyncGlobalEpochProgress.value.value + applicationConfig.failedOperationsExpirationEpochProgresses.value.value
+          )
+        ),
+        signedUpdate
+      ).some
+    } else if (allowSpendTokenA.lastValidEpochProgress.value.value < lastSyncGlobalEpochProgress.value.value) {
+      FailedCalculatedState(
+        AllowSpendExpired(allowSpendTokenA.signed.value),
+        EpochProgress(NonNegLong.unsafeFrom(lastSyncGlobalEpochProgress.value.value + 30L)),
+        signedUpdate
+      ).some
+    } else if (allowSpendTokenB.lastValidEpochProgress.value.value < lastSyncGlobalEpochProgress.value.value) {
+      FailedCalculatedState(
+        AllowSpendExpired(allowSpendTokenB.signed.value),
+        EpochProgress(NonNegLong.unsafeFrom(lastSyncGlobalEpochProgress.value.value + 30L)),
+        signedUpdate
+      ).some
+    } else {
+      None
     }
   }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/refined.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/refined.scala
@@ -32,8 +32,10 @@ object refined {
     def toNonNegLongUnsafe: NonNegLong =
       NonNegLong.unsafeFrom(value)
   }
+
   implicit class NonNegIntOps(value: Int) {
     def toNonNegIntUnsafe: NonNegInt =
       NonNegInt.unsafeFrom(value)
   }
+
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
@@ -51,16 +51,16 @@ object LiquidityPool {
   )
 
   def getLiquidityPools(state: AmmCalculatedState): Map[String, LiquidityPool] =
-    state.confirmedOperations.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
-      case liquidityPoolsCalculatedState: LiquidityPoolCalculatedState => liquidityPoolsCalculatedState.liquidityPools
+    state.operations.get(OperationType.LiquidityPool).fold(Map.empty[String, LiquidityPool]) {
+      case liquidityPoolsCalculatedState: LiquidityPoolCalculatedState => liquidityPoolsCalculatedState.confirmed.value
       case _                                                           => Map.empty
     }
 
   def getLiquidityPoolCalculatedState(
     calculatedState: AmmCalculatedState
   ): LiquidityPoolCalculatedState =
-    calculatedState.confirmedOperations
-      .get(OperationType.Staking)
+    calculatedState.operations
+      .get(OperationType.LiquidityPool)
       .collect { case t: LiquidityPoolCalculatedState => t }
       .getOrElse(LiquidityPoolCalculatedState.empty)
 
@@ -87,7 +87,7 @@ object LiquidityPool {
   def getPendingLiquidityPoolUpdates(
     state: AmmCalculatedState
   ): Set[Signed[LiquidityPoolUpdate]] =
-    state.pendingUpdates.collect {
+    getLiquidityPoolCalculatedState(state).pending.collect {
       case pendingUpdate @ Signed(liquidityPoolUpdate: LiquidityPoolUpdate, _) =>
         Signed(liquidityPoolUpdate, pendingUpdate.proofs)
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
@@ -33,7 +33,7 @@ object Staking {
   def getStakingCalculatedState(
     calculatedState: AmmCalculatedState
   ): StakingCalculatedState =
-    calculatedState.confirmedOperations
+    calculatedState.operations
       .get(OperationType.Staking)
       .collect { case t: StakingCalculatedState => t }
       .getOrElse(StakingCalculatedState.empty)
@@ -41,7 +41,7 @@ object Staking {
   def getPendingStakeUpdates(
     state: AmmCalculatedState
   ): Set[Signed[StakingUpdate]] =
-    state.pendingUpdates.collect {
+    getStakingCalculatedState(state).pending.collect {
       case pendingUpdate @ Signed(stakingUpdate: StakingUpdate, _) =>
         Signed(stakingUpdate, pendingUpdate.proofs)
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
@@ -32,9 +32,9 @@ object Swap {
   )
 
   def getSwapCalculatedState(
-    calculatedState: AmmCalculatedState
+    state: AmmCalculatedState
   ): SwapCalculatedState =
-    calculatedState.confirmedOperations
+    state.operations
       .get(OperationType.Swap)
       .collect { case t: SwapCalculatedState => t }
       .getOrElse(SwapCalculatedState.empty)
@@ -42,7 +42,7 @@ object Swap {
   def getPendingSwapUpdates(
     state: AmmCalculatedState
   ): Set[Signed[SwapUpdate]] =
-    state.pendingUpdates.collect {
+    getSwapCalculatedState(state).pending.collect {
       case pendingUpdate @ Signed(swapUpdate: SwapUpdate, _) =>
         Signed(swapUpdate, pendingUpdate.proofs)
     }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/GovernanceValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/GovernanceValidations.scala
@@ -115,7 +115,7 @@ object GovernanceValidations {
     liquidityPools: LiquidityPoolCalculatedState
   ): DataApplicationValidationErrorOr[Unit] = {
     val allocationIds = rewardAllocationVoteUpdate.allocations.map { case (id, _) => id }
-    val liquidityPoolIds = liquidityPools.liquidityPools.keySet
+    val liquidityPoolIds = liquidityPools.confirmed.value.keySet
 
     InvalidAllocationId.whenA(
       allocationIds.exists(id => !liquidityPoolIds.contains(id) && id != applicationConfig.nodeValidatorsGovernanceAllocationId)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
-import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, buildLiquidityPoolUniqueIdentifier, getLiquidityPools}
+import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 import org.amm_metagraph.shared_data.validations.Errors.{LiquidityPoolAlreadyExists, LiquidityPoolNotEnoughInformation}
 import org.amm_metagraph.shared_data.validations.SharedValidations.validateIfAllowSpendsAndSpendTransactionsAreDuplicated
@@ -25,18 +25,19 @@ object LiquidityPoolValidations {
     for {
       liquidityPoolValidationsL1 <- liquidityPoolValidationsL1(liquidityPoolUpdate)
       calculatedState = getLiquidityPools(state)
+      liquidityPoolCalculatedState = getLiquidityPoolCalculatedState(state)
       poolAlreadyExists <- validateIfPoolAlreadyExists(
         liquidityPoolUpdate,
         calculatedState
       ).handleErrorWith(_ => LiquidityPoolNotEnoughInformation.whenA(true).pure)
       tokenAAllowSpendIsDuplicated = validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
         liquidityPoolUpdate.tokenAAllowSpend,
-        state.pendingUpdates,
+        liquidityPoolCalculatedState.pending,
         state.spendTransactions
       )
       tokenBAllowSpendIsDuplicated = validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
         liquidityPoolUpdate.tokenBAllowSpend,
-        state.pendingUpdates,
+        liquidityPoolCalculatedState.pending,
         state.spendTransactions
       )
     } yield

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
@@ -29,7 +29,7 @@ object SharedValidations {
 
   def validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
     allowSpendRef: Hash,
-    existingPendingUpdates: Set[Signed[AmmUpdate]],
+    existingPendingUpdates: Set[_ <: Signed[AmmUpdate]],
     existingSpendTransactions: SortedSet[SpendTransaction]
   ): DataApplicationValidationErrorOr[Unit] = {
     val updateAlreadyExists = existingPendingUpdates.exists(_.value match {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
@@ -39,7 +39,7 @@ object StakingValidations {
     )
     confirmedTransactionAlreadyExists = validateIfConfirmedTransactionAlreadyExists(
       stakingUpdate,
-      stakingCalculatedState.confirmed.get(address)
+      stakingCalculatedState.confirmed.value.get(address)
     )
     pendingTransactionAlreadyExists = validateIfPendingTransactionAlreadyExists(
       stakingUpdate,
@@ -51,12 +51,12 @@ object StakingValidations {
     )
     tokenAAllowSpendIsDuplicated = validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
       stakingUpdate.tokenAAllowSpend,
-      state.pendingUpdates,
+      stakingCalculatedState.pending,
       state.spendTransactions
     )
     tokenBAllowSpendIsDuplicated = validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
       stakingUpdate.tokenBAllowSpend,
-      state.pendingUpdates,
+      stakingCalculatedState.pending,
       state.spendTransactions
     )
   } yield

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SwapValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SwapValidations.scala
@@ -8,6 +8,7 @@ import io.constellationnetwork.currency.dataApplication.dataApplication.DataAppl
 import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, buildLiquidityPoolUniqueIdentifier, getLiquidityPools}
 import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
+import org.amm_metagraph.shared_data.types.Swap.getSwapCalculatedState
 import org.amm_metagraph.shared_data.validations.Errors._
 import org.amm_metagraph.shared_data.validations.SharedValidations.validateIfAllowSpendsAndSpendTransactionsAreDuplicated
 
@@ -33,10 +34,11 @@ object SwapValidations {
         swapUpdate,
         liquidityPoolsCalculatedState
       )
+      swapCalculatedState = getSwapCalculatedState(state)
       swapValidationsL1 <- swapValidationsL1(swapUpdate)
       allowSpendIsDuplicated = validateIfAllowSpendsAndSpendTransactionsAreDuplicated(
         swapUpdate.allowSpendReference,
-        state.pendingUpdates,
+        swapCalculatedState.pending,
         state.spendTransactions
       )
     } yield

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/DummyL0Context.scala
@@ -59,7 +59,9 @@ object DummyL0Context {
       def getLastCurrencySnapshotCombined: F[Option[(Hashed[CurrencyIncrementalSnapshot], CurrencySnapshotInfo)]] = ???
       def securityProvider: SecurityProvider[F] = ???
       def getCurrencyId: F[CurrencyId] = CurrencyId(metagraphAddress).pure[F]
-      def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = ???
+      def getLastSynchronizedGlobalSnapshot: F[Option[Hashed[GlobalIncrementalSnapshot]]] = for {
+        globalIncrementalSnapshot <- buildGlobalIncrementalSnapshot[F](keyPair, gsEpochProgress)
+      } yield Some(globalIncrementalSnapshot)
       def getLastSynchronizedGlobalSnapshotCombined: F[Option[(Hashed[GlobalIncrementalSnapshot], GlobalSnapshotInfo)]] = for {
         globalIncrementalSnapshot <- buildGlobalIncrementalSnapshot[F](keyPair, gsEpochProgress)
         globalSnapshotInfo = buildGlobalSnapshotInfo(allowSpends)

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
@@ -25,7 +25,7 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.all.PosLong
+import eu.timepit.refined.types.all.{NonNegLong, PosLong}
 import eu.timepit.refined.types.numeric.PosDouble
 import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.app.ApplicationConfig.{Dev, Governance, VotingWeightMultipliers}
@@ -38,6 +38,19 @@ import weaver.MutableIOSuite
 
 object LiquidityPoolValidationTest extends MutableIOSuite {
   type Res = (Hasher[IO], SecurityProvider[IO])
+
+  private val config = ApplicationConfig(
+    EpochProgress(NonNegLong.unsafeFrom(30L)),
+    "NodeValidators",
+    Dev,
+    Governance(
+      VotingWeightMultipliers(
+        PosDouble.MinValue,
+        PosDouble.MinValue,
+        PosDouble.MinValue
+      )
+    )
+  )
 
   override def sharedResource: Resource[IO, Res] = for {
     sp <- SecurityProvider.forAsync[IO]
@@ -61,7 +74,12 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       tokenA.amount.value.fromTokenAmountFormat * tokenB.amount.value.fromTokenAmountFormat,
       PoolShares(1L.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
     )
-    (poolId.value, LiquidityPoolCalculatedState(Map(poolId.value -> liquidityPool)))
+    (
+      poolId.value,
+      LiquidityPoolCalculatedState.empty.copy(confirmed =
+        ConfirmedLiquidityPoolCalculatedState.empty.copy(value = Map(poolId.value -> liquidityPool))
+      )
+    )
   }
 
   def getFakeSignedUpdate(
@@ -103,18 +121,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       EpochProgress.MaxValue
     )
 
-    val config = ApplicationConfig(
-      "NodeValidators",
-      Dev,
-      Governance(
-        VotingWeightMultipliers(
-          PosDouble.MinValue,
-          PosDouble.MinValue,
-          PosDouble.MinValue
-        )
-      )
-    )
-
     for {
       validationService <- ValidationService.make[IO](config)
       response <- validationService.validateUpdate(liquidityPoolUpdate)
@@ -134,18 +140,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       primaryToken.amount,
       pairToken.amount,
       EpochProgress.MaxValue
-    )
-
-    val config = ApplicationConfig(
-      "NodeValidators",
-      Dev,
-      Governance(
-        VotingWeightMultipliers(
-          PosDouble.MinValue,
-          PosDouble.MinValue,
-          PosDouble.MinValue
-        )
-      )
     )
 
     for {
@@ -181,17 +175,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     )
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
-    val config = ApplicationConfig(
-      "NodeValidators",
-      Dev,
-      Governance(
-        VotingWeightMultipliers(
-          PosDouble.MinValue,
-          PosDouble.MinValue,
-          PosDouble.MinValue
-        )
-      )
-    )
 
     for {
       validationService <- ValidationService.make[IO](config)
@@ -220,17 +203,7 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     )
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
-    val config = ApplicationConfig(
-      "NodeValidators",
-      Dev,
-      Governance(
-        VotingWeightMultipliers(
-          PosDouble.MinValue,
-          PosDouble.MinValue,
-          PosDouble.MinValue
-        )
-      )
-    )
+
     for {
       validationService <- ValidationService.make[IO](config)
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
@@ -258,17 +231,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     )
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
-    val config = ApplicationConfig(
-      "NodeValidators",
-      Dev,
-      Governance(
-        VotingWeightMultipliers(
-          PosDouble.MinValue,
-          PosDouble.MinValue,
-          PosDouble.MinValue
-        )
-      )
-    )
 
     for {
       validationService <- ValidationService.make[IO](config)
@@ -310,17 +272,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
     )
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
-    val config = ApplicationConfig(
-      "NodeValidators",
-      Dev,
-      Governance(
-        VotingWeightMultipliers(
-          PosDouble.MinValue,
-          PosDouble.MinValue,
-          PosDouble.MinValue
-        )
-      )
-    )
 
     for {
       validationService <- ValidationService.make[IO](config)


### PR DESCRIPTION
### Changes
+ Introduced the new failed operations to the calculated state
+ The calculated state was refactored to have separated: `confirmed`, `pending` and `failed` operations
+ New tests added
+ Added failure validations to the Staking and LiquidityPool

### Notes
 + We still need to fix current tests, I'll fix them after merging the `withdraw` branch, which changes some variable types