### PR TITLE
fix: allow spend hashes and global confirmation

### DIFF
--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/CombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/CombinerService.scala
@@ -24,6 +24,7 @@ import org.amm_metagraph.shared_data.combiners.SwapCombiner.combineSwap
 import org.amm_metagraph.shared_data.combiners.WithdrawalCombiner.combineWithdrawal
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.States._
+import org.amm_metagraph.shared_data.types.codecs.HasherSelector
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -35,7 +36,7 @@ trait CombinerService[F[_]] {
 }
 
 object CombinerService {
-  def make[F[_]: Async: Hasher: SecurityProvider](
+  def make[F[_]: Async: HasherSelector: SecurityProvider](
     applicationConfig: ApplicationConfig
   ): F[CombinerService[F]] = Async[F].delay {
     new CombinerService[F] {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawalCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/combiners/WithdrawalCombiner.scala
@@ -24,6 +24,7 @@ import org.amm_metagraph.shared_data.types.DataUpdates.WithdrawalUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.Withdrawal.{WithdrawalCalculatedStateAddress, getWithdrawalCalculatedState}
+import org.amm_metagraph.shared_data.types.codecs.HasherSelector
 
 object WithdrawalCombiner {
   private case class WithdrawalTokenAmounts(
@@ -108,7 +109,7 @@ object WithdrawalCombiner {
     )
   }
 
-  def combineWithdrawal[F[_]: Async: Hasher](
+  def combineWithdrawal[F[_]: Async](
     acc: DataState[AmmOnChainState, AmmCalculatedState],
     signedWithdrawalUpdate: Signed[WithdrawalUpdate],
     signerAddress: Address,

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/globalSnapshots.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/globalSnapshots.scala
@@ -3,14 +3,10 @@ package org.amm_metagraph.shared_data
 import cats.effect.Async
 import cats.syntax.all._
 
-import scala.collection.immutable.{SortedMap, SortedSet}
-
 import io.constellationnetwork.currency.dataApplication.L0NodeContext
-import io.constellationnetwork.schema.address.Address
-import io.constellationnetwork.schema.swap.AllowSpend
+import io.constellationnetwork.schema.swap.{AllowSpend, CurrencyId}
 import io.constellationnetwork.schema.{GlobalIncrementalSnapshot, GlobalSnapshotInfo}
 import io.constellationnetwork.security.hash.Hash
-import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher}
 
 import org.typelevel.log4cats.SelfAwareStructuredLogger
@@ -39,21 +35,36 @@ object globalSnapshots {
     }
 
   def getAllowSpendLastSyncGlobalSnapshotState[F[_]: Async: Hasher](
-    allowSpendHash: Hash
+    allowSpendHash: Hash,
+    tokenId: Option[CurrencyId]
   )(implicit context: L0NodeContext[F]): F[Option[Hashed[AllowSpend]]] = for {
     globalSnapshotInfo <- getLastSyncGlobalSnapshotState
-    currencyId <- context.getCurrencyId
-    activeAllowSpends = globalSnapshotInfo.activeAllowSpends
-      .getOrElse(SortedMap.empty[Option[Address], SortedMap[Address, SortedSet[Signed[AllowSpend]]]])
+    confirmedAllowSpend <- findAllowSpendInGlobalState(allowSpendHash, tokenId, globalSnapshotInfo)
+  } yield confirmedAllowSpend
 
-    response <- activeAllowSpends.get(currencyId.value.some) match {
-      case Some(active) =>
-        active.values.flatten.toList.traverse(_.toHashed).map { hashedAllowSpends =>
-          hashedAllowSpends.find(_.hash === allowSpendHash)
+  def getAllowSpendsLastSyncGlobalSnapshotState[F[_]: Async: Hasher](
+    allowSpendHashA: Hash,
+    tokenAId: Option[CurrencyId],
+    allowSpendHashB: Hash,
+    tokenBId: Option[CurrencyId]
+  )(implicit context: L0NodeContext[F]): F[(Option[Hashed[AllowSpend]], Option[Hashed[AllowSpend]])] = for {
+    globalSnapshotInfo <- getLastSyncGlobalSnapshotState
+    confirmedAllowSpendA <- findAllowSpendInGlobalState(allowSpendHashA, tokenAId, globalSnapshotInfo)
+    confirmedAllowSpendB <- findAllowSpendInGlobalState(allowSpendHashB, tokenBId, globalSnapshotInfo)
+  } yield (confirmedAllowSpendA, confirmedAllowSpendB)
+
+  private def findAllowSpendInGlobalState[F[_]: Async: Hasher](
+    allowSpendHash: Hash,
+    tokenId: Option[CurrencyId],
+    globalSnapshotInfo: GlobalSnapshotInfo
+  ): F[Option[Hashed[AllowSpend]]] =
+    globalSnapshotInfo.activeAllowSpends.flatTraverse { activeAllowSpends =>
+      activeAllowSpends.get(tokenId.map(_.value)).flatTraverse { tokenAllowSpends =>
+        tokenAllowSpends.values.toList.flatten.collectFirstSomeM { activeAllowSpend =>
+          activeAllowSpend.toHashed.map { hashed =>
+            Option.when(hashed.hash === allowSpendHash)(hashed)
+          }
         }
-      case None =>
-        none.pure
+      }
     }
-  } yield response
-
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
@@ -2,14 +2,12 @@ package org.amm_metagraph.shared_data.types
 
 import java.time._
 
-import cats.Order
+import cats.Order._
 import cats.effect.kernel.Async
-import cats.syntax.functor._
-import cats.syntax.semigroup._
+import cats.syntax.all._
 
 import io.constellationnetwork.ext.crypto._
 import io.constellationnetwork.ext.derevo.ordering
-import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.tokenLock.TokenLock
@@ -21,7 +19,7 @@ import derevo.cats.order
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import enumeratum.values.{StringCirceEnum, StringEnum, StringEnumEntry}
-import eu.timepit.refined.auto.autoRefineV
+import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.numeric.{NonNegDouble, NonNegInt, NonNegLong}
 import io.circe.refined._
@@ -36,18 +34,14 @@ import org.amm_metagraph.shared_data.types.DataUpdates.RewardAllocationVoteUpdat
 object Governance {
   val maxCredits = 50.0
 
+  @derive(decoder, encoder, order, ordering)
   @newtype
-  @derive(order, encoder, decoder)
   case class RewardAllocationVoteOrdinal(value: NonNegLong) {
     def next: RewardAllocationVoteOrdinal = RewardAllocationVoteOrdinal(value |+| 1L)
   }
 
   object RewardAllocationVoteOrdinal {
     val first: RewardAllocationVoteOrdinal = RewardAllocationVoteOrdinal(0L)
-
-    implicit val decoder: Decoder[RewardAllocationVoteOrdinal] = deriving
-    implicit val encoder: Encoder[RewardAllocationVoteOrdinal] = deriving
-    implicit val orderInstance: Order[RewardAllocationVoteOrdinal] = Order.by(_.value)
   }
 
   @derive(decoder, encoder, order, ordering)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Staking.scala
@@ -1,12 +1,11 @@
 package org.amm_metagraph.shared_data.types
 
-import cats.Order
+import cats.Order._
 import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.ext.crypto.RefinedHasher
 import io.constellationnetwork.ext.derevo.ordering
-import io.constellationnetwork.schema._
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher}
@@ -14,16 +13,17 @@ import io.constellationnetwork.security.{Hashed, Hasher}
 import derevo.cats.order
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import eu.timepit.refined.auto.autoRefineV
+import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
-import eu.timepit.refined.types.all.NonNegLong
-import io.circe.{Decoder, Encoder}
+import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.refined._
 import io.estatico.newtype.macros.newtype
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.TokenInformation
 import org.amm_metagraph.shared_data.types.States.{AmmCalculatedState, OperationType, StakingCalculatedState}
 
 object Staking {
+
   @derive(encoder, decoder)
   case class StakingCalculatedStateAddress(
     tokenAAllowSpend: Hash,
@@ -47,18 +47,14 @@ object Staking {
     val empty: StakingReference = StakingReference(StakingOrdinal(0L), Hash.empty)
   }
 
+  @derive(decoder, encoder, order, ordering)
   @newtype
-  @derive(order, encoder, decoder)
   case class StakingOrdinal(value: NonNegLong) {
     def next: StakingOrdinal = StakingOrdinal(value |+| 1L)
   }
 
   object StakingOrdinal {
     val first: StakingOrdinal = StakingOrdinal(1L)
-
-    implicit val decoder: Decoder[StakingOrdinal] = deriving
-    implicit val encoder: Encoder[StakingOrdinal] = deriving
-    implicit val orderInstance: Order[StakingOrdinal] = Order.by(_.value)
   }
 
   def getStakingCalculatedState(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Withdrawal.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Withdrawal.scala
@@ -1,12 +1,11 @@
 package org.amm_metagraph.shared_data.types
 
-import cats.Order
+import cats.Order._
 import cats.effect.Async
 import cats.syntax.all._
 
 import io.constellationnetwork.ext.crypto.RefinedHasher
 import io.constellationnetwork.ext.derevo.ordering
-import io.constellationnetwork.schema._
 import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -15,10 +14,10 @@ import io.constellationnetwork.security.{Hashed, Hasher}
 import derevo.cats.order
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import eu.timepit.refined.auto.autoRefineV
+import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.all.NonNegLong
-import io.circe.{Decoder, Encoder}
+import io.circe.refined._
 import io.estatico.newtype.macros.newtype
 import org.amm_metagraph.shared_data.types.DataUpdates.WithdrawalUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.ShareAmount
@@ -47,18 +46,14 @@ object Withdrawal {
     val empty: WithdrawalReference = WithdrawalReference(WithdrawalOrdinal(0L), Hash.empty)
   }
 
+  @derive(decoder, encoder, order, ordering)
   @newtype
-  @derive(order, encoder, decoder)
   case class WithdrawalOrdinal(value: NonNegLong) {
     def next: WithdrawalOrdinal = WithdrawalOrdinal(value |+| 1L)
   }
 
   object WithdrawalOrdinal {
     val first: WithdrawalOrdinal = WithdrawalOrdinal(1L)
-
-    implicit val decoder: Decoder[WithdrawalOrdinal] = deriving
-    implicit val encoder: Encoder[WithdrawalOrdinal] = deriving
-    implicit val orderInstance: Order[WithdrawalOrdinal] = Order.by(_.value)
   }
 
   def getWithdrawalCalculatedState(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/codecs/HasherSelector.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/codecs/HasherSelector.scala
@@ -1,0 +1,16 @@
+package org.amm_metagraph.shared_data.types.codecs
+
+import io.constellationnetwork.security.Hasher
+
+trait HasherSelector[F[_]] {
+  def withBrotli[A](fn: Hasher[F] => A): A
+  def withCurrent[A](fn: Hasher[F] => A): A
+}
+
+object HasherSelector {
+  def apply[F[_]: HasherSelector]: HasherSelector[F] = implicitly
+  def forSync[F[_]](hasherBrotli: Hasher[F], hasherCurrent: Hasher[F]): HasherSelector[F] = new HasherSelector[F] {
+    def withBrotli[A](fn: Hasher[F] => A): A = fn(hasherBrotli)
+    def withCurrent[A](fn: Hasher[F] => A): A = fn(hasherCurrent)
+  }
+}

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -33,9 +33,10 @@ import org.amm_metagraph.shared_data.types.DataUpdates.SwapUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
 import weaver.MutableIOSuite
+import org.amm_metagraph.shared_data.types.codecs.HasherSelector
 
 object SwapCombinerTest extends MutableIOSuite {
-  type Res = (Hasher[IO], SecurityProvider[IO])
+  type Res = (Hasher[IO], HasherSelector[IO], SecurityProvider[IO])
 
   private val config = ApplicationConfig(
     EpochProgress(NonNegLong.unsafeFrom(30L)),
@@ -56,7 +57,8 @@ object SwapCombinerTest extends MutableIOSuite {
     sp <- SecurityProvider.forAsync[IO]
     implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
     h = Hasher.forJson[IO]
-  } yield (h, sp)
+    hs = HasherSelector.forSync(h, h)
+  } yield (h, hs, sp)
 
   def buildLiquidityPoolCalculatedState(
     tokenA: TokenInformation,
@@ -111,7 +113,7 @@ object SwapCombinerTest extends MutableIOSuite {
     )
 
   test("Test swap successfully when liquidity pool exists - providing min and max price") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken = TokenInformation(
       CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some,
@@ -201,7 +203,7 @@ object SwapCombinerTest extends MutableIOSuite {
   }
 
   test("Test swap successfully when liquidity pool exists - not providing min and max price") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken = TokenInformation(
       CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some,
@@ -291,7 +293,7 @@ object SwapCombinerTest extends MutableIOSuite {
   }
 
   test("Test swap failure when liquidity pool exists - minPrice too high") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken = TokenInformation(
       CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some,
@@ -371,7 +373,7 @@ object SwapCombinerTest extends MutableIOSuite {
   }
 
   test("Test swap failure when liquidity pool exists - maxPrice too low") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken = TokenInformation(
       CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some,
@@ -451,7 +453,7 @@ object SwapCombinerTest extends MutableIOSuite {
   }
 
   test("Test swap failure when liquidity pool exists - minAmount too high") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken = TokenInformation(
       CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some,
@@ -531,7 +533,7 @@ object SwapCombinerTest extends MutableIOSuite {
   }
 
   test("Test swap - pending swap without allow spend") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken =
       TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)
@@ -601,7 +603,7 @@ object SwapCombinerTest extends MutableIOSuite {
   }
 
   test("Test swap - ignore swap that exceed limit epoch progress") { implicit res =>
-    implicit val (h, sp) = res
+    implicit val (h, hs, sp) = res
 
     val primaryToken =
       TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 1000000L.toTokenAmountFormat.toPosLongUnsafe)


### PR DESCRIPTION
- fixed hasher used for hashing allow spends from `GlobalSnapshotInfo`
- fixed `derevo`
- fixed `getAllowSpendLastSyncGlobalSnapshotState` implementation