### PR TITLE
feat: add pool fees distributed on swap

### DIFF
--- a/.github/action_scripts/shared/api/liquidity-pool.ts
+++ b/.github/action_scripts/shared/api/liquidity-pool.ts
@@ -19,6 +19,12 @@ type LiquidityPool = {
     }
 }
 
+type PoolFees = {
+    total: number
+    providers: number
+    operators: number
+}
+
 type LiquidityPoolUpdate = {
     source: string
     tokenAAllowSpend: string
@@ -27,7 +33,8 @@ type LiquidityPoolUpdate = {
     tokenBId?: string | null
     tokenAAmount: number
     tokenBAmount: number
-    maxValidGsEpochProgress: number
+    maxValidGsEpochProgress: number,
+    poolFees: PoolFees
 }
 
 type LiquidityUpdateBody = {
@@ -58,6 +65,11 @@ const createLiquidityPoolUpdate = async (
             tokenBAllowSpend: tokenBAllowSpendHash,
             tokenBAmount,
             tokenBId,
+            poolFees: {
+                total: 0.0,
+                providers: 0.0,
+                operators: 0.0
+            }
         }
     };
     const serialized = await serializeBase64(body)

--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/custom_routes/SwapRoutes.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/custom_routes/SwapRoutes.scala
@@ -27,7 +27,7 @@ import org.amm_metagraph.shared_data.refined.Percentage._
 import org.amm_metagraph.shared_data.services.pricing.PricingService
 import org.amm_metagraph.shared_data.types.DataUpdates.{AmmUpdate, SwapUpdate}
 import org.amm_metagraph.shared_data.types.LiquidityPool._
-import org.amm_metagraph.shared_data.types.States.{OperationType, LiquidityPoolCalculatedState, SwapCalculatedState}
+import org.amm_metagraph.shared_data.types.States.{LiquidityPoolCalculatedState, OperationType, SwapCalculatedState}
 import org.amm_metagraph.shared_data.types.Swap._
 import org.amm_metagraph.shared_data.types.codecs.{HasherSelector, JsonWithBase64BinaryCodec}
 import org.http4s.circe.CirceEntityCodec._

--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/rewards/RewardsCalculator.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/rewards/RewardsCalculator.scala
@@ -118,11 +118,11 @@ class RewardCalculator(config: ApplicationConfig.Rewards) {
     val yearRemainder = if (isLastEpochInYear(currentProgress)) {
       config.governancePool.value.value % epochProgress1Year
     } else 0L
+    val totalPower = votingPowers.map(_.power.total.value).sum
 
-    (if (votingPowers.isEmpty) {
+    (if (votingPowers.isEmpty || totalPower === 0L) {
        EitherT.pure[F, RewardError](Map.empty[Address, Amount])
      } else {
-       val totalPower = votingPowers.map(_.power.total.value).sum
        val totalForEpoch = basePerEpoch + yearRemainder
 
        for {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/FeeDistributor.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/FeeDistributor.scala
@@ -1,0 +1,104 @@
+package org.amm_metagraph.shared_data
+
+import cats.Order
+import cats.syntax.semigroup._
+
+import scala.math.BigDecimal.RoundingMode
+
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
+
+import derevo.cats.eqv
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import eu.timepit.refined.types.all.NonNegLong
+import org.amm_metagraph.shared_data.refined.Percentage._
+import org.amm_metagraph.shared_data.refined._
+import org.amm_metagraph.shared_data.types.LiquidityPool.PoolShares
+
+object FeeDistributor {
+
+  def getFeeShare(feeShares: Map[Address, NonNegLong], address: Address): NonNegLong =
+    feeShares.getOrElse(address, 0L.toNonNegLongUnsafe)
+
+  def standard: FeePercentages = FeePercentages(
+    Percentage.unsafeFrom(0.3),
+    Percentage.unsafeFrom(0.25),
+    Percentage.unsafeFrom(0.05)
+  )
+
+  def empty: FeePercentages = FeePercentages(
+    Percentage.unsafeFrom(0.0),
+    Percentage.unsafeFrom(0.0),
+    Percentage.unsafeFrom(0.0)
+  )
+
+  @derive(eqv, encoder, decoder)
+  case class FeePercentages(total: Percentage, providers: Percentage, operators: Percentage)
+
+  object FeePercentages {
+    implicit val order: Order[FeePercentages] = Order.by(_.total)
+  }
+
+  @derive(eqv, encoder, decoder)
+  case class FeeAmounts(total: Long, providers: Long, operators: Long)
+
+  def calculateFeeAmounts(
+    amountBeforeFee: BigInt,
+    feeDistribution: FeePercentages
+  ): FeeAmounts = {
+    val totalFeeAmount = (BigDecimal(amountBeforeFee) * feeDistribution.total.toDecimal)
+      .setScale(0, RoundingMode.HALF_UP)
+      .toLong
+
+    val totalPercentage = feeDistribution.providers.value + feeDistribution.operators.value
+
+    if (totalPercentage == BigDecimal(0)) FeeAmounts(0L, 0L, 0L)
+    else {
+      val providerPortion = feeDistribution.providers.value / totalPercentage
+      val providerFeeAmount = (BigDecimal(totalFeeAmount) * providerPortion)
+        .setScale(0, RoundingMode.HALF_UP)
+        .toLong
+
+      val operatorFeeAmount = totalFeeAmount - providerFeeAmount
+
+      FeeAmounts(totalFeeAmount, providerFeeAmount, operatorFeeAmount)
+    }
+  }
+
+  def distributeProviderFees(
+    providerFeeAmount: Long,
+    operatorFeeAmount: Long,
+    poolShares: PoolShares,
+    metagraphId: CurrencyId
+  ): Map[Address, NonNegLong] = {
+    val totalShares = poolShares.totalShares.value
+    val currentFeeShares = poolShares.feeShares
+
+    if (totalShares == 0) currentFeeShares
+    else {
+      val providerDistribution = poolShares.addressShares.foldLeft(Map.empty[Address, Long]) {
+        case (distributionMap, (address, shareAmount)) =>
+          val sharePercentage = BigDecimal(shareAmount.value.value.value) / BigDecimal(totalShares)
+          val providerFeeShareAmount = (providerFeeAmount * sharePercentage)
+            .setScale(0, RoundingMode.HALF_UP)
+            .toLong
+
+          distributionMap + (address -> providerFeeShareAmount)
+      }
+
+      val roundingDifference = providerFeeAmount - providerDistribution.values.sum
+      val operatorDistribution = Map(metagraphId.value -> (operatorFeeAmount + roundingDifference))
+
+      val latestFeeShares = providerDistribution |+| operatorDistribution
+
+      latestFeeShares.foldLeft(currentFeeShares) {
+        case (acc, (address, amount)) =>
+          val current = acc.getOrElse(address, 0L.toNonNegLongUnsafe)
+          val updated = (current.value + amount).toNonNegLongUnsafe
+
+          acc + (address -> updated)
+      }
+    }
+  }
+}

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfig.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfig.scala
@@ -18,7 +18,9 @@ object ApplicationConfig {
 
   sealed trait Environment
   case object Dev extends Environment
-  case object Prod extends Environment
+  case object Testnet extends Environment
+  case object Integrationnet extends Environment
+  case object Mainnet extends Environment
 
   case class VotingWeightMultipliers(
     lockForSixMonthsMultiplier: PosDouble,

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfigOps.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/app/ApplicationConfigOps.scala
@@ -48,9 +48,11 @@ object ConfigReaders {
   }
 
   implicit val configReader: ConfigReader[Environment] = ConfigReader.fromString[Environment] {
-    case "dev"  => Right(Dev)
-    case "prod" => Right(Prod)
-    case other  => Left(CannotConvert(other, "Environment", "Must be 'dev' or 'prod'"))
+    case "dev"            => Right(Dev)
+    case "testnet"        => Right(Testnet)
+    case "integrationnet" => Right(Integrationnet)
+    case "mainnet"        => Right(Mainnet)
+    case other            => Left(CannotConvert(other, "Environment", "Must be 'dev', 'testnet', 'integrationnet', or 'mainnet'"))
   }
 
   implicit val applicationConfigReader: ConfigReader[ApplicationConfig] = deriveReader

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/refined.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/refined.scala
@@ -1,8 +1,8 @@
 package org.amm_metagraph.shared_data
 
-import scala.math.BigDecimal.RoundingMode
+import cats.{Eq, Order}
 
-import io.constellationnetwork.security.hash.Hash
+import scala.math.BigDecimal.RoundingMode
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Interval
@@ -79,6 +79,9 @@ object refined {
       Decoder.decodeBigDecimal.emap { value =>
         eu.timepit.refined.refineV[PercentageRange](value)
       }
+
+    implicit val percentageEq: Eq[Percentage] = Eq.by(_.value)
+    implicit val percentageOrder: Order[Percentage] = Order.by(_.value)
 
     implicit class PercentageOps(percentage: Percentage) {
       lazy val toDecimal: BigDecimal = percentage.value.setScale(8) / BigDecimal(100)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/L0CombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/L0CombinerService.scala
@@ -199,7 +199,8 @@ object L0CombinerService {
         pendingSpendActionStaking: Set[PendingSpendAction[StakingUpdate]],
         pendingSpendActionWithdrawals: Set[PendingSpendAction[WithdrawalUpdate]],
         pendingSpendActionSwap: Set[PendingSpendAction[SwapUpdate]],
-        stateCombinedByPendingAllowSpends: DataState[AmmOnChainState, AmmCalculatedState]
+        stateCombinedByPendingAllowSpends: DataState[AmmOnChainState, AmmCalculatedState],
+        currencyId: CurrencyId
       )(implicit context: L0NodeContext[F]) =
         if (globalSnapshotSyncSpendActions.isEmpty) {
           stateCombinedByPendingAllowSpends.pure
@@ -246,7 +247,8 @@ object L0CombinerService {
                     acc,
                     lastSyncGlobalEpochProgress,
                     globalSnapshotSyncSpendActions,
-                    currencySnapshotOrdinal
+                    currencySnapshotOrdinal,
+                    currencyId
                   )
               }
           } yield stateUpdatedBySwap
@@ -336,7 +338,8 @@ object L0CombinerService {
               pendingSpendActionStaking,
               pendingSpendActionWithdrawals,
               pendingSpendActionSwap,
-              stateCombinedByPendingAllowSpendUpdates
+              stateCombinedByPendingAllowSpendUpdates,
+              currencyId
             )
 
           stateCombinedGovernanceRewards = governanceCombinerService.handleMonthlyGovernanceRewards(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/StakingCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/StakingCombinerService.scala
@@ -87,7 +87,8 @@ object StakingCombinerService {
           k = BigInt(updatedTokenAAmount.value) * BigInt(updatedTokenBAmount.value),
           poolShares = PoolShares(
             (liquidityPool.poolShares.totalShares.value + newlyIssuedShares).toPosLongUnsafe,
-            updatedAddressShares
+            updatedAddressShares,
+            liquidityPool.poolShares.feeShares
           )
         )
       }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/WithdrawalCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/WithdrawalCombinerService.scala
@@ -231,7 +231,8 @@ object WithdrawalCombinerService {
             k = k,
             poolShares = PoolShares(
               totalSharesAmount,
-              updatedAddressShares
+              updatedAddressShares,
+              liquidityPool.poolShares.feeShares
             )
           )
       }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
@@ -11,7 +11,11 @@ import io.constellationnetwork.security.hash.Hash
 import derevo.cats.eqv
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
+import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.PosLong
+import org.amm_metagraph.shared_data.FeeDistributor.FeePercentages
+import org.amm_metagraph.shared_data.refined.Percentage
+import org.amm_metagraph.shared_data.refined.Percentage._
 import org.amm_metagraph.shared_data.types.Governance.{RewardAllocationVoteOrdinal, RewardAllocationVoteReference}
 import org.amm_metagraph.shared_data.types.LiquidityPool.ShareAmount
 import org.amm_metagraph.shared_data.types.Staking.{StakingOrdinal, StakingReference}
@@ -33,7 +37,8 @@ object DataUpdates {
     tokenBId: Option[CurrencyId],
     tokenAAmount: PosLong,
     tokenBAmount: PosLong,
-    maxValidGsEpochProgress: EpochProgress
+    maxValidGsEpochProgress: EpochProgress,
+    poolFees: Option[FeePercentages]
   ) extends AmmUpdate
 
   @derive(eqv, decoder, encoder)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
@@ -117,7 +117,7 @@ object Governance {
             EpochProgress(NonNegLong.unsafeFrom(globalEpochProgress.value.value + 3L)),
             YearMonth.now(ZoneId.of("UTC")).getMonth.getValue.toNonNegIntUnsafe
           )
-        case ApplicationConfig.Prod =>
+        case _ =>
           def getSecondsUntilMonthEnd: Long = {
             val now = LocalDateTime.now(ZoneId.of("UTC"))
             val lastDayOfMonth = YearMonth.now(ZoneId.of("UTC")).atEndOfMonth()

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/LiquidityPool.scala
@@ -14,9 +14,12 @@ import io.constellationnetwork.security.signature.Signed
 import derevo.cats.{eqv, show}
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
-import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
 import io.circe.refined._
 import io.estatico.newtype.macros.newtype
+import org.amm_metagraph.shared_data.FeeDistributor.FeePercentages
+import org.amm_metagraph.shared_data.refined.Percentage._
+import org.amm_metagraph.shared_data.refined._
 import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
 import org.amm_metagraph.shared_data.types.States._
 
@@ -42,7 +45,8 @@ object LiquidityPool {
   @derive(encoder, decoder)
   case class PoolShares(
     totalShares: PosLong,
-    addressShares: Map[Address, ShareAmount]
+    addressShares: Map[Address, ShareAmount],
+    feeShares: Map[Address, NonNegLong]
   )
 
   @derive(encoder, decoder)
@@ -52,7 +56,8 @@ object LiquidityPool {
     tokenB: TokenInformation,
     owner: Address,
     k: BigInt,
-    poolShares: PoolShares
+    poolShares: PoolShares,
+    poolFees: FeePercentages
   )
 
   def getLiquidityPools(state: AmmCalculatedState): Map[String, LiquidityPool] =

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Swap.scala
@@ -61,7 +61,8 @@ object Swap {
   case class SwapTokenInfo(
     primaryTokenInformation: TokenInformation,
     pairTokenInformation: TokenInformation,
-    receivedAmount: SwapAmount
+    grossReceived: SwapAmount,
+    netReceived: SwapAmount
   )
 
   @derive(decoder, encoder, order, ordering)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -132,4 +132,12 @@ object Errors {
   case object TokenIdsAreTheSame extends DataApplicationValidationError {
     val message = "Token ids are the same but should be different"
   }
+
+  case object FeePercentagesMustEqualTotal extends DataApplicationValidationError {
+    val message = "Fee percentage components must sum to total"
+  }
+
+  case object FeePercentageTotalMustBeGreaterThanZero extends DataApplicationValidationError {
+    val message = "Fee percentage total must be greater than zero"
+  }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidations.scala
@@ -7,29 +7,40 @@ import io.constellationnetwork.currency.dataApplication.dataApplication.DataAppl
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
+import org.amm_metagraph.shared_data.app.ApplicationConfig
+import org.amm_metagraph.shared_data.app.ApplicationConfig.Environment
+import org.amm_metagraph.shared_data.refined.Percentage
+import org.amm_metagraph.shared_data.refined.Percentage._
 import org.amm_metagraph.shared_data.types.DataUpdates.LiquidityPoolUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
-import org.amm_metagraph.shared_data.validations.Errors.{LiquidityPoolAlreadyExists, LiquidityPoolNotEnoughInformation}
+import org.amm_metagraph.shared_data.validations.Errors._
 import org.amm_metagraph.shared_data.validations.SharedValidations._
 
 object LiquidityPoolValidations {
   def liquidityPoolValidationsL1[F[_]: Async](
+    applicationConfig: ApplicationConfig,
     liquidityPoolUpdate: LiquidityPoolUpdate
   ): F[DataApplicationValidationErrorOr[Unit]] = Async[F].delay {
     val tokensArePresent = validateIfTokensArePresent(liquidityPoolUpdate)
     val tokenIdsAreTheSame = validateIfTokenIdsAreTheSame(liquidityPoolUpdate.tokenAId, liquidityPoolUpdate.tokenBId)
+    val componentsSumToTotal = validateComponentsSumToTotal(liquidityPoolUpdate)
+    val feePercentage = validateFeePercentage(applicationConfig.environment, liquidityPoolUpdate)
 
-    tokensArePresent.productR(tokenIdsAreTheSame)
+    tokensArePresent
+      .productR(tokenIdsAreTheSame)
+      .productR(feePercentage)
+      .productR(componentsSumToTotal)
   }
 
   def liquidityPoolValidationsL0[F[_]: Async: SecurityProvider](
+    applicationConfig: ApplicationConfig,
     signedLiquidityPoolUpdate: Signed[LiquidityPoolUpdate],
     state: AmmCalculatedState
   ): F[DataApplicationValidationErrorOr[Unit]] = {
     val liquidityPoolUpdate = signedLiquidityPoolUpdate.value
     for {
-      l1Validations <- liquidityPoolValidationsL1(liquidityPoolUpdate)
+      l1Validations <- liquidityPoolValidationsL1(applicationConfig, liquidityPoolUpdate)
       signatures <- signatureValidations(signedLiquidityPoolUpdate, signedLiquidityPoolUpdate.source)
 
       calculatedState = getLiquidityPools(state)
@@ -68,4 +79,34 @@ object LiquidityPoolValidations {
     for {
       poolId <- buildLiquidityPoolUniqueIdentifier(liquidityPoolUpdate.tokenAId, liquidityPoolUpdate.tokenBId)
     } yield LiquidityPoolAlreadyExists.whenA(currentLiquidityPools.contains(poolId.value))
+
+  private def validateComponentsSumToTotal(
+    liquidityPoolUpdate: LiquidityPoolUpdate
+  ): DataApplicationValidationErrorOr[Unit] =
+    liquidityPoolUpdate.poolFees match {
+      case Some(percentages) =>
+        if (percentages.total.toDecimal == percentages.providers.toDecimal + percentages.operators.toDecimal) {
+          valid
+        } else FeePercentagesMustEqualTotal.invalidNec
+      case None => valid
+
+    }
+
+  private def validateFeePercentage(
+    environment: Environment,
+    liquidityPoolUpdate: LiquidityPoolUpdate
+  ): DataApplicationValidationErrorOr[Unit] =
+    if (liquidityPoolUpdate.poolFees.isEmpty) {
+      valid // Since we will get the standard value when it's none
+    } else {
+      val feePercentages = liquidityPoolUpdate.poolFees.get
+      if (feePercentages.total <= Percentage.zero)
+        environment match {
+          case ApplicationConfig.Dev | ApplicationConfig.Testnet => valid
+          case _                                                 => FeePercentageTotalMustBeGreaterThanZero.invalidNec
+        }
+      else
+        valid
+
+    }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
@@ -38,7 +38,7 @@ object ValidationService {
       private def validateL1(update: AmmUpdate): F[DataApplicationValidationErrorOr[Unit]] = update match {
         case stakingUpdate: StakingUpdate                           => stakingValidationsL1(stakingUpdate)
         case withdrawalUpdate: WithdrawalUpdate                     => withdrawalValidationsL1(withdrawalUpdate)
-        case liquidityPoolUpdate: LiquidityPoolUpdate               => liquidityPoolValidationsL1(liquidityPoolUpdate)
+        case liquidityPoolUpdate: LiquidityPoolUpdate               => liquidityPoolValidationsL1(applicationConfig, liquidityPoolUpdate)
         case swapUpdate: SwapUpdate                                 => swapValidationsL1(swapUpdate)
         case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate => rewardAllocationValidationsL1(rewardAllocationVoteUpdate)
       }
@@ -55,7 +55,7 @@ object ValidationService {
             case stakingUpdate: StakingUpdate       => stakingValidationsL0(Signed(stakingUpdate, signedUpdate.proofs), state)
             case withdrawalUpdate: WithdrawalUpdate => withdrawalValidationsL0(Signed(withdrawalUpdate, signedUpdate.proofs), state)
             case liquidityPoolUpdate: LiquidityPoolUpdate =>
-              liquidityPoolValidationsL0(Signed(liquidityPoolUpdate, signedUpdate.proofs), state)
+              liquidityPoolValidationsL0(applicationConfig, Signed(liquidityPoolUpdate, signedUpdate.proofs), state)
             case swapUpdate: SwapUpdate => swapValidationsL0(Signed(swapUpdate, signedUpdate.proofs), state)
             case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate =>
               rewardAllocationValidationsL0(

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/CombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/CombinerTest.scala
@@ -25,6 +25,7 @@ import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvi
 import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.{NonNegLong, PosDouble, PosLong}
+import org.amm_metagraph.shared_data.FeeDistributor
 import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.app.ApplicationConfig._
 import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
@@ -94,7 +95,8 @@ object CombinerTest extends MutableIOSuite {
       tokenB,
       owner,
       BigInt(tokenA.amount.value) * BigInt(tokenB.amount.value),
-      PoolShares(totalShares, shares)
+      PoolShares(totalShares, shares, Map.empty),
+      FeeDistributor.empty
     )
     (
       poolId.value,
@@ -175,7 +177,8 @@ object CombinerTest extends MutableIOSuite {
           tokenBId,
           tokenAAmount,
           tokenBAmount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 
@@ -318,7 +321,8 @@ object CombinerTest extends MutableIOSuite {
           tokenBId,
           tokenAAmount,
           tokenBAmount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 
@@ -450,7 +454,8 @@ object CombinerTest extends MutableIOSuite {
           tokenBId,
           tokenAAmount,
           tokenBAmount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -146,7 +146,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
           tokenBId,
           tokenAAmount,
           tokenBAmount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 
@@ -260,7 +261,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
           tokenBId,
           tokenAAmount,
           tokenBAmount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 
@@ -385,7 +387,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
           pairToken.identifier,
           primaryToken.amount,
           pairToken.amount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 
@@ -494,7 +497,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
           pairToken.identifier,
           primaryToken.amount,
           pairToken.amount,
-          EpochProgress.MaxValue
+          EpochProgress.MaxValue,
+          None
         )
       )
 

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/combiners/StakingCombinerTest.scala
@@ -26,6 +26,7 @@ import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.{NonNegLong, PosLong}
 import eu.timepit.refined.types.numeric.PosDouble
+import org.amm_metagraph.shared_data.FeeDistributor
 import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.app.ApplicationConfig._
 import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
@@ -46,6 +47,7 @@ object StakingCombinerTest extends MutableIOSuite {
   val sourceAddress: Address = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
 
   private def toFixedPoint(decimal: Double): Long = (decimal * 1e8).toLong
+
   private val config = ApplicationConfig(
     EpochProgress(NonNegLong.unsafeFrom(30L)),
     "NodeValidators",
@@ -96,7 +98,8 @@ object StakingCombinerTest extends MutableIOSuite {
       tokenB,
       owner,
       BigInt(tokenA.amount.value) * BigInt(tokenB.amount.value),
-      PoolShares(totalShares, shares)
+      PoolShares(totalShares, shares, Map.empty),
+      FeeDistributor.empty
     )
     (
       poolId.value,

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -28,6 +28,7 @@ import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.{NonNegLong, PosLong}
 import eu.timepit.refined.types.numeric.PosDouble
+import org.amm_metagraph.shared_data.FeeDistributor
 import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.app.ApplicationConfig._
 import org.amm_metagraph.shared_data.refined._
@@ -87,7 +88,12 @@ object StakingValidationTest extends MutableIOSuite {
       tokenB,
       owner,
       BigInt(tokenA.amount.value) * BigInt(tokenB.amount.value),
-      PoolShares(1.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
+      PoolShares(
+        1.toTokenAmountFormat.toPosLongUnsafe,
+        Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))),
+        Map(owner -> 0L.toNonNegLongUnsafe)
+      ),
+      FeeDistributor.empty
     )
     (
       poolId.value,

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/SwapValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/SwapValidationTest.scala
@@ -28,6 +28,7 @@ import com.my.dor_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.all.{NonNegLong, PosLong}
 import eu.timepit.refined.types.numeric.PosDouble
+import org.amm_metagraph.shared_data.FeeDistributor
 import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.app.ApplicationConfig._
 import org.amm_metagraph.shared_data.refined._
@@ -86,7 +87,12 @@ object SwapValidationTest extends MutableIOSuite {
       tokenB,
       owner,
       BigInt(tokenA.amount.value) * BigInt(tokenB.amount.value),
-      PoolShares(1.toTokenAmountFormat.toPosLongUnsafe, Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))))
+      PoolShares(
+        1.toTokenAmountFormat.toPosLongUnsafe,
+        Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(1e8.toLong)))),
+        Map(owner -> 0L.toNonNegLongUnsafe)
+      ),
+      FeeDistributor.empty
     )
     (
       poolId.value,


### PR DESCRIPTION
- Adds fees for liquidity providers and network operators to be assessed during `SwapCombiner` operation
- `FeeDistributor & Percentage` functionality realize the mechanism used by the lifecycle functions
- Added a unit test to `SwapCombinerTest` to test expected behavior of a `0.3%` fee split between providers and operators