### PR TITLE
fix: shared validation when both tokenIds are equal with short-circuit on L1

### DIFF
--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -121,4 +121,8 @@ object Errors {
   case object DuplicatedOperation extends DataApplicationValidationError {
     val message = "Duplicated operation"
   }
+
+  case object TokenIdsAreTheSame extends DataApplicationValidationError {
+    val message = "Token ids are the same but should be different"
+  }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
@@ -9,6 +9,8 @@ import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.validations.Errors._
+import org.checkerframework.checker.units.qual.Current
+import io.constellationnetwork.schema.swap.CurrencyId
 
 object SharedValidations {
   private def isSignedExclusivelyBySourceValidation[F[_]: Async: SecurityProvider, A](
@@ -31,6 +33,12 @@ object SharedValidations {
   } yield
     singleSignatureValidation
       .productR(exclusivelySignedBySourceAddress)
+
+  def validateIfTokenIdsAreTheSame(
+    tokenAId: Option[CurrencyId],
+    tokenBId: Option[CurrencyId]
+  ): DataApplicationValidationErrorOr[Unit] =
+    TokenIdsAreTheSame.whenA(tokenAId === tokenBId)
 
   def validateIfAllowSpendsAreDuplicated(
     allowSpendRef: Hash,


### PR DESCRIPTION
Some invalid cases could be rejected right away on L1 instead of waiting for L0 consensus.
Also some validations are common between DataUpdates, so it is worth to share the method.