### PR TITLE
ci: test allow spend partial spends

### DIFF
--- a/.github/action_scripts/governance/token-lock/index.ts
+++ b/.github/action_scripts/governance/token-lock/index.ts
@@ -1,7 +1,7 @@
 import { dag4 } from "@stardust-collective/dag4";
 import jsSha256 from "js-sha256";
 import axios from "axios";
-import { BaseAmmMetagraphCliArgsSchema, delay, getGlobalSnapshotCombined, getPublicKey, log, retry, serializeBrotli, validateIfSyncedToGlobalOrdinal } from "../../shared";
+import { BaseAmmMetagraphCliArgsSchema, delay, getGlobalSnapshotCombined, getPublicKey, log, Logger, retry, serializeBrotli, validateIfSyncedToGlobalOrdinal } from "../../shared";
 import { z } from 'zod';
 
 const tokenLocks = [
@@ -99,7 +99,7 @@ const sendSignedTokenLock = async (config, signedTokenLock) => {
 const validateTokenLockInGL0 = async (
     config: ReturnType<typeof createConfig>,
     walletAddress: string,
-    logger: (message: string, type?: string, context?: string) => void = log
+    logger: Logger = log
 ) => {
     const { gl0Url, metagraphId } = config;
 

--- a/.github/action_scripts/shared/api/balances.ts
+++ b/.github/action_scripts/shared/api/balances.ts
@@ -7,8 +7,6 @@ import { AllowSpend } from "./allow-spends";
 import { TokenConfig } from "./token";
 
 const getBalance = async (tokenConfig: TokenConfig) => {
-    log(`Getting balance for account: ${tokenConfig.account.address} `, "INFO", tokenConfig.context);
-
     try {
         const snapshotUrl = tokenConfig.isCurrency
             ? `${tokenConfig.l0Url}/snapshots/latest/combined`
@@ -32,17 +30,6 @@ const getBalance = async (tokenConfig: TokenConfig) => {
     }
 }
 
-
-const validateIfBalanceChangedByAllowSpend = async (
-    initialBalance: number,
-    tokenAllowSpend: Signed<AllowSpend>,
-    tokenConfig: TokenConfig,
-    logger: Logger
-) => {
-    const expectedBalance = initialBalance - tokenAllowSpend.value.amount - tokenAllowSpend.value.fee;
-    await validateIfBalanceChanged(initialBalance, expectedBalance, tokenConfig, logger);
-}
-
 const validateIfBalanceChanged = async (
     initialBalance: number,
     expectedBalance: number,
@@ -52,10 +39,8 @@ const validateIfBalanceChanged = async (
     const balance = await getBalance(tokenConfig);
     if (balance !== expectedBalance) {
         const msg = `Balance different than expected. Actual: ${balance} (Δ ${balance - initialBalance}). Expected: ${expectedBalance} (Δ ${expectedBalance - initialBalance})`;
-        logger(msg, "ERROR", tokenConfig.context);
         throwInContext(tokenConfig.context)(msg);
     }
-    logger(`Balance change validated!`, "INFO", tokenConfig.context);
 }
 
-export { getBalance, validateIfBalanceChangedByAllowSpend, validateIfBalanceChanged };
+export { getBalance, validateIfBalanceChanged };

--- a/.github/action_scripts/shared/api/token.ts
+++ b/.github/action_scripts/shared/api/token.ts
@@ -11,8 +11,6 @@ type TokenConfig<T extends object = {}> = {
     isCurrency: boolean;
 } & T
 
-type TokenConfigWithAllowSpend = TokenConfig<{ allowSpendAmount: number }>
-
 const createTokenConfig = async <T extends object = {}>(
     privateKey: string,
     l0Url: string,
@@ -36,4 +34,4 @@ const createTokenConfig = async <T extends object = {}>(
     };
 }
 
-export { createTokenConfig, type TokenConfig, type TokenConfigWithAllowSpend };
+export { createTokenConfig, type TokenConfig };

--- a/.github/action_scripts/shared/log.ts
+++ b/.github/action_scripts/shared/log.ts
@@ -9,8 +9,10 @@ const colors = {
     white: "\x1b[37m",
 };
 
+type LogType = "INFO" | "WARN" | "ERROR" | "EMPTY" | "SUCCESS";
+
 // Color mapping for different log types
-const typeColors = {
+const typeColors: Record<LogType, string> = {
     "INFO": colors.white,
     "WARN": colors.yellow,
     "ERROR": colors.red,
@@ -18,7 +20,9 @@ const typeColors = {
     "SUCCESS": colors.green,
 };
 
-const log = (message: string, type = "INFO", context?: string, indent?: number) => {
+type Logger = (message: string, type?: LogType, context?: string, indent?: number) => void;
+
+const log: Logger = (message: string, type: LogType = "INFO", context?: string, indent?: number) => {
     const timestamp = new Date().toISOString();
     const indentStr = indent ? ' '.repeat(indent) : '';
 
@@ -36,7 +40,7 @@ const log = (message: string, type = "INFO", context?: string, indent?: number) 
     }
 };
 
-const logObject = (object: any, context?: string, indent?: number) => {
+const logObject = (object: any) => {
     console.log('\n' + JSON.stringify(object, null, 2))
 }
 
@@ -44,4 +48,9 @@ const throwInContext = (context: string) => (message: string) => {
     throw new Error(`[${context}] ${message}`);
 }
 
-export { log, logObject, throwInContext };
+const createIndentedLogger = (logger: Logger, indent: number): Logger =>
+    (message: string, type?: LogType, context?: string) => {
+        logger(message, type, context, indent);
+    };
+
+export { log, logObject, throwInContext, createIndentedLogger, type Logger };

--- a/.github/action_scripts/shared/retry.ts
+++ b/.github/action_scripts/shared/retry.ts
@@ -1,15 +1,7 @@
-import { log } from "./log";
+import { createIndentedLogger, log, Logger } from "./log";
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-type Severity = "INFO" | "WARN" | "ERROR" | "EMPTY" | "SUCCESS";
-type Logger = (message: string, type?: string | undefined, context?: string | undefined, indent?: number) => void;
-
-
-const createIndentedLogger = (logger: Logger, indent: number): Logger =>
-    (message: string, type?: string, context?: string) => {
-        logger(message, type, context, indent);
-    };
 
 type RetryFunction<T> = (logger: Logger) => Promise<T>;
 
@@ -46,4 +38,4 @@ const retry = <T>(context: string, config: Partial<RetryConfig> = defaultRetryCo
     throw new Error("Unreachable - loop will always either return or throw");
 }
 
-export { delay, retry, Logger, Severity };
+export { delay, retry, Logger };

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   call-workflow-setup-environment:
     uses: ./.github/workflows/setup-environment.yml
     with:
-      # tessellation_commit_hash: "261c1de72bd33a626056264462143028df1f90e6"
+      # tessellation_commit_hash: "9003e0eef8fcbc7b74d9983db5111963900f0c0a"
       use_merge_commit: true
     secrets: inherit
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/SpendTransactions.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/SpendTransactions.scala
@@ -70,21 +70,23 @@ object SpendTransactions {
 
   def generateSpendAction(
     hashedAllowSpendA: Hashed[AllowSpend],
-    hashedAllowSpendB: Hashed[AllowSpend]
+    amountToSpendA: SwapAmount,
+    hashedAllowSpendB: Hashed[AllowSpend],
+    amountToSpendB: SwapAmount
   ): SpendAction =
     SpendAction(
       NonEmptyList.of(
         SpendTransaction(
           hashedAllowSpendA.hash.some,
           hashedAllowSpendA.currencyId,
-          hashedAllowSpendA.amount,
+          amountToSpendA,
           hashedAllowSpendA.source,
           hashedAllowSpendA.destination
         ),
         SpendTransaction(
           hashedAllowSpendB.hash.some,
           hashedAllowSpendB.currencyId,
-          hashedAllowSpendB.amount,
+          amountToSpendB,
           hashedAllowSpendB.source,
           hashedAllowSpendB.destination
         )

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/LiquidityPoolCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/LiquidityPoolCombinerService.scala
@@ -12,7 +12,7 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.schema.artifact.{SharedArtifact, SpendAction}
 import io.constellationnetwork.schema.balance.Amount
 import io.constellationnetwork.schema.epoch.EpochProgress
-import io.constellationnetwork.schema.swap.{AllowSpend, CurrencyId}
+import io.constellationnetwork.schema.swap.{AllowSpend, CurrencyId, SwapAmount}
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
@@ -245,7 +245,15 @@ object LiquidityPoolCombinerService {
                   case Some(failedCalculatedState) =>
                     handleFailedUpdate(updates, oldState, failedCalculatedState, liquidityPoolsCalculatedState).pure
                   case None =>
-                    val spendAction = generateSpendAction(allowSpendTokenA, allowSpendTokenB)
+                    val amountToSpendA = SwapAmount(liquidityPoolUpdate.tokenAAmount)
+                    val amountToSpendB = SwapAmount(liquidityPoolUpdate.tokenBAmount)
+
+                    val spendAction = generateSpendAction(
+                      allowSpendTokenA,
+                      amountToSpendA,
+                      allowSpendTokenB,
+                      amountToSpendB
+                    )
 
                     val updatedPendingAllowSpendCalculatedState =
                       removePendingAllowSpend(liquidityPoolsCalculatedState, signedUpdate)

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/WithdrawalCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/WithdrawalCombinerService.scala
@@ -50,8 +50,8 @@ object WithdrawalCombinerService {
     new WithdrawalCombinerService[F] {
 
       private case class WithdrawalTokenAmounts(
-        tokenAAmount: PosLong,
-        tokenBAmount: PosLong
+        tokenAAmount: SwapAmount,
+        tokenBAmount: SwapAmount
       )
 
       private def getExpireEpochProgress(lastSyncGlobalEpochProgress: EpochProgress): EpochProgress = EpochProgress(
@@ -135,7 +135,7 @@ object WithdrawalCombinerService {
               signedUpdate
             )
           )
-        } yield WithdrawalTokenAmounts(tokenAAmount, tokenBAmount)
+        } yield WithdrawalTokenAmounts(SwapAmount(tokenAAmount), SwapAmount(tokenBAmount))
       }
 
       private def handleFailedUpdate(
@@ -276,9 +276,9 @@ object WithdrawalCombinerService {
           withdrawalAmounts <- EitherT.fromEither[F](calculateWithdrawalAmounts(signedUpdate, liquidityPool, globalEpochProgress))
           spendAction = generateSpendActionWithoutAllowSpends(
             signedUpdate.tokenAId,
-            SwapAmount(withdrawalAmounts.tokenAAmount),
+            withdrawalAmounts.tokenAAmount,
             signedUpdate.tokenBId,
-            SwapAmount(withdrawalAmounts.tokenBAmount),
+            withdrawalAmounts.tokenBAmount,
             signedUpdate.source,
             currencyId
           )
@@ -350,7 +350,9 @@ object WithdrawalCombinerService {
                 )
                 withdrawalCalculatedStateAddress = WithdrawalCalculatedStateAddress(
                   withdrawalUpdate.tokenAId,
+                  withdrawalAmounts.tokenAAmount,
                   withdrawalUpdate.tokenBId,
+                  withdrawalAmounts.tokenBAmount,
                   withdrawalUpdate.shareToWithdraw,
                   withdrawalReference
                 )

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
@@ -36,7 +36,7 @@ object DataUpdates {
     maxValidGsEpochProgress: EpochProgress
   ) extends AmmUpdate
 
-  @derive(decoder, encoder)
+  @derive(eqv, decoder, encoder)
   case class StakingUpdate(
     source: Address,
     tokenAAllowSpend: Hash,

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Withdrawal.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Withdrawal.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 
 import io.constellationnetwork.ext.crypto.RefinedHasher
 import io.constellationnetwork.ext.derevo.ordering
-import io.constellationnetwork.schema.swap.CurrencyId
+import io.constellationnetwork.schema.swap.{CurrencyId, SwapAmount}
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hashed, Hasher}
@@ -27,7 +27,9 @@ object Withdrawal {
   @derive(encoder, decoder)
   case class WithdrawalCalculatedStateAddress(
     tokenAId: Option[CurrencyId],
+    tokenAAmount: SwapAmount,
     tokenBId: Option[CurrencyId],
+    tokenBAmount: SwapAmount,
     shareToWithdraw: ShareAmount,
     parent: WithdrawalReference
   )

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
@@ -5,6 +5,7 @@ import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -12,7 +13,6 @@ import io.constellationnetwork.security.signature.Signed
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.validations.Errors._
 import org.checkerframework.checker.units.qual.Current
-import io.constellationnetwork.schema.swap.CurrencyId
 
 object SharedValidations {
   private def isSignedExclusivelyBySourceValidation[F[_]: Async: SecurityProvider, A](


### PR DESCRIPTION
- All the test cases now use actual spend to check expected balances instead of total allow spend (so test works for partial spends and total spends)
- Generated spend transactions now use actual spend instead of total allow spend