### PR TITLE
fix: allow spend comparison for duplicated staking transactions

### DIFF
--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
@@ -86,13 +86,23 @@ object StakingValidations {
     stakingUpdate: StakingUpdate,
     maybeConfirmedStaking: Option[Set[StakingCalculatedStateAddress]]
   ): DataApplicationValidationErrorOr[Unit] =
-    StakingTransactionAlreadyExists.whenA(maybeConfirmedStaking.exists(_.exists(_.tokenAAllowSpend == stakingUpdate.tokenBAllowSpend)))
+    StakingTransactionAlreadyExists.whenA(
+      maybeConfirmedStaking.exists(
+        _.exists(staking =>
+          staking.tokenAAllowSpend == stakingUpdate.tokenAAllowSpend || staking.tokenBAllowSpend == stakingUpdate.tokenBAllowSpend
+        )
+      )
+    )
 
   private def validateIfPendingTransactionAlreadyExists(
     stakingUpdate: StakingUpdate,
     maybePendingStaking: Set[Signed[StakingUpdate]]
   ): DataApplicationValidationErrorOr[Unit] =
-    StakingTransactionAlreadyExists.whenA(maybePendingStaking.exists(_.tokenAAllowSpend == stakingUpdate.tokenBAllowSpend))
+    StakingTransactionAlreadyExists.whenA(
+      maybePendingStaking.exists(staking =>
+        staking.value.tokenAAllowSpend == stakingUpdate.tokenAAllowSpend || staking.value.tokenBAllowSpend == stakingUpdate.tokenBAllowSpend
+      )
+    )
 
   private def validateIfLiquidityPoolExists[F[_]: Async](
     stakingUpdate: StakingUpdate,

--- a/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/dor_metagraph/shared_data/validations/StakingValidationTest.scala
@@ -291,8 +291,8 @@ object StakingValidationTest extends MutableIOSuite {
             Map(
               signerAddress -> Set(
                 StakingCalculatedStateAddress(
-                  Hash.empty,
-                  Hash.empty,
+                  Hash("allowSpendA"),
+                  Hash("allowSpendB"),
                   primaryToken,
                   pairToken,
                   StakingReference.empty
@@ -308,8 +308,8 @@ object StakingValidationTest extends MutableIOSuite {
     val state = DataState(ammOnChainState, ammCalculatedState)
     val stakingUpdate = StakingUpdate(
       sourceAddress,
-      Hash.empty,
-      Hash.empty,
+      Hash("allowSpendA"),
+      Hash("allowSpendB"),
       primaryToken.identifier,
       100L.toPosLongUnsafe,
       pairToken.identifier,


### PR DESCRIPTION
The test was always passing `Hash.empty === Hash.empty` but in reality the validation was broken.