### PR TITLE
fix: use Eq instance instead of ==

### DIFF
--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/rewards/RewardsCalculator.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/rewards/RewardsCalculator.scala
@@ -65,7 +65,7 @@ class RewardCalculator(config: ApplicationConfig.Rewards) {
 
   private def isLastEpochInYear(currentEpoch: EpochProgress): Boolean = {
     val epochsSinceStart = currentEpoch.value.value - config.initialEpoch.value.value
-    (epochsSinceStart + 1) % epochProgress1Year == 0
+    (epochsSinceStart + 1) % epochProgress1Year === 0
   }
 
   private def calculateValidatorShare(
@@ -139,7 +139,7 @@ class RewardCalculator(config: ApplicationConfig.Rewards) {
              for {
                random <- EitherT.liftF(Random.scalaUtilRandomSeedLong(currentProgress.value.value))
                maxPower = votingPowers.map(_.power.total.value).max
-               highestPowerVoters = votingPowers.filter(_.power.total.value == maxPower)
+               highestPowerVoters = votingPowers.filter(_.power.total.value === maxPower)
                shuffled <- EitherT.liftF(random.shuffleList(highestPowerVoters))
                luckyVoter = shuffled.head
                updatedAmount = baseDistribution(luckyVoter.address).value.value + remainder

--- a/modules/l0/src/test/scala/org/amm_metagraph/l0/rewards/RewardsCalculatorSpec.scala
+++ b/modules/l0/src/test/scala/org/amm_metagraph/l0/rewards/RewardsCalculatorSpec.scala
@@ -96,7 +96,7 @@ object RewardsCalculatorSpec extends SimpleIOSuite {
           rewards.daoRewards._2.value.value +
           rewards.votingRewards.values.map(_.value.value).sum
 
-      expect(totalRewards == expectedPerEpoch)
+      expect(totalRewards === expectedPerEpoch)
     }
   }
 
@@ -111,8 +111,8 @@ object RewardsCalculatorSpec extends SimpleIOSuite {
     }
 
     whenSuccessF(result.value) { rewards =>
-      val allValidatorsGetSameAmount = rewards.validatorRewards.values.toSet.size == 1
-      val allValidatorsAreRewarded = rewards.validatorRewards.size == validators.length
+      val allValidatorsGetSameAmount = rewards.validatorRewards.values.toSet.size === 1
+      val allValidatorsAreRewarded = rewards.validatorRewards.size === validators.length
 
       expect.all(
         allValidatorsGetSameAmount,
@@ -162,7 +162,7 @@ object RewardsCalculatorSpec extends SimpleIOSuite {
     }
 
     whenSuccessF(result.value) { rewards =>
-      expect(rewards.votingRewards.keySet == Set(voterA))
+      expect(rewards.votingRewards.keySet === Set(voterA))
     }
   }
 
@@ -185,7 +185,7 @@ object RewardsCalculatorSpec extends SimpleIOSuite {
 
       expect(actualDAOReward > baseDAOShare) &&
       expect(remainderPortion > 0L) &&
-      expect(actualDAOReward == baseDAOShare + remainderPortion)
+      expect(actualDAOReward === baseDAOShare + remainderPortion)
     }
   }
 
@@ -251,7 +251,7 @@ object RewardsCalculatorSpec extends SimpleIOSuite {
       val totalDistributed = totalValidatorRewards + totalDaoRewards + totalVotingRewards
       val annualAmount = config.totalAnnualTokens.value.value
 
-      expect(totalDistributed == annualAmount) &&
+      expect(totalDistributed === annualAmount) &&
       // Base proportions should be maintained for distributable amount (excluding remainders in DAO)
       expect((totalValidatorRewards * 100L / annualAmount - config.validatorWeight.value).abs <= 1) &&
       expect((totalVotingRewards * 100L / annualAmount - config.votingWeight.value).abs <= 1)
@@ -397,7 +397,7 @@ object RewardsCalculatorSpec extends SimpleIOSuite {
     }
 
     whenSuccessF(result.value) { totalGovernanceRewards =>
-      expect(totalGovernanceRewards == config.governancePool.value.value)
+      expect(totalGovernanceRewards === config.governancePool.value.value)
     }
   }
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/LiquidityPoolCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/LiquidityPoolCombinerService.scala
@@ -4,7 +4,6 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
-import scala.tools.nsc.tasty.SafeEq
 
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.schema.SnapshotOrdinal

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/StakingCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/StakingCombinerService.scala
@@ -4,7 +4,6 @@ import cats.effect.Async
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
-import scala.tools.nsc.tasty.SafeEq
 
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.schema.SnapshotOrdinal
@@ -191,8 +190,8 @@ object StakingCombinerService {
         signedStakingUpdate: Signed[StakingUpdate]
       ) =
         stakingCalculatedState.pending.filterNot {
-          case PendingAllowSpend(update) if update == signedStakingUpdate => true
-          case _                                                          => false
+          case PendingAllowSpend(update) if update === signedStakingUpdate => true
+          case _                                                           => false
         }
 
       private def removePendingSpendAction(
@@ -200,8 +199,8 @@ object StakingCombinerService {
         signedStakingUpdate: Signed[StakingUpdate]
       ) =
         stakingCalculatedState.pending.filterNot {
-          case PendingSpendAction(update, _) if update == signedStakingUpdate => true
-          case _                                                              => false
+          case PendingSpendAction(update, _) if update === signedStakingUpdate => true
+          case _                                                               => false
         }
 
       def combineNew(

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/SwapCombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/SwapCombinerService.scala
@@ -162,8 +162,8 @@ object SwapCombinerService {
         signedSwapUpdate: Signed[SwapUpdate]
       ) =
         swapCalculatedState.pending.filterNot {
-          case PendingAllowSpend(update) if update == signedSwapUpdate => true
-          case _                                                       => false
+          case PendingAllowSpend(update) if update === signedSwapUpdate => true
+          case _                                                        => false
         }
 
       private def removePendingSpendAction(
@@ -171,8 +171,8 @@ object SwapCombinerService {
         signedSwapUpdate: Signed[SwapUpdate]
       ) =
         swapCalculatedState.pending.filterNot {
-          case PendingSpendAction(update, _) if update == signedSwapUpdate => true
-          case _                                                           => false
+          case PendingSpendAction(update, _) if update === signedSwapUpdate => true
+          case _                                                            => false
         }
 
       def combineNew(
@@ -191,7 +191,7 @@ object SwapCombinerService {
           case None =>
             val updatedPendingSwapsCalculatedState = if (swapUpdate.maxValidGsEpochProgress < globalEpochProgress) {
               removePendingAllowSpend(swapCalculatedState, signedUpdate)
-            } else if (!swapCalculatedStatePendingAllowSpend.exists(_.update == signedUpdate)) {
+            } else if (!swapCalculatedStatePendingAllowSpend.exists(_.update === signedUpdate)) {
               swapCalculatedStatePendingAllowSpend + PendingAllowSpend(signedUpdate)
             } else {
               swapCalculatedStatePendingAllowSpend

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/pricing/PricingService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/pricing/PricingService.scala
@@ -82,7 +82,7 @@ object PricingService {
       ): Either[String, SwapQuote] =
         for {
           (_, newOutputReserve, estimatedReceived) <- calculateReservesAndReceived(pool, fromTokenId, amount)
-          outputToken = if (fromTokenId == pool.tokenA.identifier) pool.tokenB else pool.tokenA
+          outputToken = if (fromTokenId === pool.tokenA.identifier) pool.tokenB else pool.tokenA
 
           _ <- Either.cond(
             outputToken.identifier === toTokenId,

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/DataUpdates.scala
@@ -8,7 +8,7 @@ import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap.{CurrencyId, SwapAmount}
 import io.constellationnetwork.security.hash.Hash
 
-import derevo.cats.{eqv, show}
+import derevo.cats.eqv
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.types.numeric.PosLong
@@ -24,7 +24,7 @@ object DataUpdates {
     val source: Address
   }
 
-  @derive(decoder, encoder)
+  @derive(eqv, decoder, encoder)
   case class LiquidityPoolUpdate(
     source: Address,
     tokenAAllowSpend: Hash,
@@ -36,7 +36,7 @@ object DataUpdates {
     maxValidGsEpochProgress: EpochProgress
   ) extends AmmUpdate
 
-  @derive(decoder, encoder)
+  @derive(eqv, decoder, encoder)
   case class StakingUpdate(
     source: Address,
     tokenAAllowSpend: Hash,
@@ -62,7 +62,7 @@ object DataUpdates {
     val ordinal: WithdrawalOrdinal = parent.ordinal.next
   }
 
-  @derive(decoder, encoder)
+  @derive(eqv, decoder, encoder)
   case class SwapUpdate(
     source: Address,
     swapFromPair: Option[CurrencyId],

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/types/Governance.scala
@@ -83,7 +83,7 @@ object Governance {
 
     implicit val encoder: Encoder[AllocationCategory] = Encoder.encodeString.contramap(_.value)
     implicit val decoder: Decoder[AllocationCategory] = Decoder.decodeString.emap { str =>
-      values.find(_.value == str).toRight(s"Invalid AllocationCategory value: $str")
+      values.find(_.value === str).toRight(s"Invalid AllocationCategory value: $str")
     }
   }
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -5,6 +5,9 @@ import cats.syntax.all._
 import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
+import derevo.cats.eqv
+import derevo.derive
+
 object Errors {
   private type DataApplicationValidationType = DataApplicationValidationErrorOr[Unit]
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/SharedValidations.scala
@@ -5,6 +5,7 @@ import cats.syntax.all._
 
 import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.hash.Hash
 import io.constellationnetwork.security.signature.Signed
@@ -12,7 +13,6 @@ import io.constellationnetwork.security.signature.Signed
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.validations.Errors._
 import org.checkerframework.checker.units.qual.Current
-import io.constellationnetwork.schema.swap.CurrencyId
 
 object SharedValidations {
   private def isSignedExclusivelyBySourceValidation[F[_]: Async: SecurityProvider, A](
@@ -47,10 +47,10 @@ object SharedValidations {
     existingPendingUpdates: Set[_ <: Signed[AmmUpdate]]
   ): DataApplicationValidationErrorOr[Unit] = {
     val updateAlreadyExists = existingPendingUpdates.exists(_.value match {
-      case lpUpdate: LiquidityPoolUpdate => lpUpdate.tokenAAllowSpend == allowSpendRef || lpUpdate.tokenBAllowSpend == allowSpendRef
+      case lpUpdate: LiquidityPoolUpdate => lpUpdate.tokenAAllowSpend === allowSpendRef || lpUpdate.tokenBAllowSpend === allowSpendRef
       case stakingUpdate: StakingUpdate =>
-        stakingUpdate.tokenAAllowSpend == allowSpendRef || stakingUpdate.tokenBAllowSpend == allowSpendRef
-      case swapUpdate: SwapUpdate => swapUpdate.allowSpendReference == allowSpendRef
+        stakingUpdate.tokenAAllowSpend === allowSpendRef || stakingUpdate.tokenBAllowSpend === allowSpendRef
+      case swapUpdate: SwapUpdate => swapUpdate.allowSpendReference === allowSpendRef
       case _                      => false
     })
 

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/StakingValidations.scala
@@ -1,6 +1,5 @@
 package org.amm_metagraph.shared_data.validations
 
-import cats.data.Validated.Invalid
 import cats.effect.Async
 import cats.syntax.all._
 
@@ -9,7 +8,6 @@ import io.constellationnetwork.schema.address.Address
 import io.constellationnetwork.security.SecurityProvider
 import io.constellationnetwork.security.signature.Signed
 
-import eu.timepit.refined.auto._
 import org.amm_metagraph.shared_data.types.DataUpdates.StakingUpdate
 import org.amm_metagraph.shared_data.types.LiquidityPool.{LiquidityPool, buildLiquidityPoolUniqueIdentifier, getLiquidityPools}
 import org.amm_metagraph.shared_data.types.Staking._
@@ -90,7 +88,7 @@ object StakingValidations {
     StakingTransactionAlreadyExists.whenA(
       maybeConfirmedStaking.exists(
         _.exists(staking =>
-          staking.tokenAAllowSpend == stakingUpdate.tokenAAllowSpend || staking.tokenBAllowSpend == stakingUpdate.tokenBAllowSpend
+          staking.tokenAAllowSpend === stakingUpdate.tokenAAllowSpend || staking.tokenBAllowSpend === stakingUpdate.tokenBAllowSpend
         )
       )
     )
@@ -101,7 +99,7 @@ object StakingValidations {
   ): DataApplicationValidationErrorOr[Unit] =
     StakingTransactionAlreadyExists.whenA(
       maybePendingStaking.exists(staking =>
-        staking.value.tokenAAllowSpend == stakingUpdate.tokenAAllowSpend || staking.value.tokenBAllowSpend == stakingUpdate.tokenBAllowSpend
+        staking.value.tokenAAllowSpend === stakingUpdate.tokenAAllowSpend || staking.value.tokenBAllowSpend === stakingUpdate.tokenBAllowSpend
       )
     )
 


### PR DESCRIPTION
We had a lot of places in AMM where we used `==` instead of `===`. We should use `Eq` instance instead because it won't allow any number widening in opposite to `==`.