### PR TITLE
feat: adding address query params LP routes

### DIFF
--- a/modules/l0/src/test/scala/org/amm_metagraph/l0/Shared.scala
+++ b/modules/l0/src/test/scala/org/amm_metagraph/l0/Shared.scala
@@ -1,0 +1,93 @@
+package org.amm_metagraph.l0
+
+import scala.concurrent.duration.DurationInt
+
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Amount
+import io.constellationnetwork.schema.epoch.EpochProgress
+import io.constellationnetwork.schema.swap.CurrencyId
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.{NonNegLong, PosDouble, PosLong}
+import org.amm_metagraph.shared_data.FeeDistributor
+import org.amm_metagraph.shared_data.FeeDistributor.FeePercentages
+import org.amm_metagraph.shared_data.app.ApplicationConfig
+import org.amm_metagraph.shared_data.app.ApplicationConfig._
+import org.amm_metagraph.shared_data.refined._
+import org.amm_metagraph.shared_data.types.LiquidityPool._
+import org.amm_metagraph.shared_data.types.States.{ConfirmedLiquidityPoolCalculatedState, LiquidityPoolCalculatedState}
+
+object Shared {
+  val ammMetagraphId: Address = Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9z5")
+  val ammMetagraphIdAsCurrencyId: CurrencyId = CurrencyId(ammMetagraphId)
+  val sourceAddress: Address = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
+
+  val config = ApplicationConfig(
+    ExpirationEpochProgresses(
+      EpochProgress(NonNegLong.unsafeFrom(30L)),
+      EpochProgress(NonNegLong.unsafeFrom(30L))
+    ),
+    "NodeValidators",
+    Dev,
+    Governance(
+      VotingWeightMultipliers(
+        PosDouble.MinValue,
+        PosDouble.MinValue,
+        PosDouble.MinValue
+      )
+    ),
+    Rewards(
+      Amount.empty,
+      Amount.empty,
+      NonNegLong.MinValue,
+      NonNegLong.MinValue,
+      NonNegLong.MinValue,
+      EpochProgress.MinValue,
+      Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")
+    ),
+    TokenLimits(
+      NonNegLong.unsafeFrom((100 * 1e8).toLong),
+      NonNegLong.unsafeFrom((9223372036854775000L * 1e8).toLong)
+    ),
+    EpochProgress(NonNegLong.unsafeFrom(0L)),
+    EpochMetadata(43.seconds)
+  )
+
+  def buildLiquidityPoolCalculatedState(
+    tokenA: TokenInformation,
+    tokenB: TokenInformation,
+    owner: Address,
+    additionalProvider: Option[(Address, ShareAmount)] = None,
+    fees: FeePercentages = FeeDistributor.empty
+  ): (String, LiquidityPoolCalculatedState) = {
+    val primaryAddressAsString = tokenA.identifier.fold("")(address => address.value.value)
+    val pairAddressAsString = tokenB.identifier.fold("")(address => address.value.value)
+    val poolId = PoolId(s"$primaryAddressAsString-$pairAddressAsString")
+
+    val baseShares = Map(owner -> ShareAmount(Amount(PosLong.unsafeFrom(toFixedPoint(1.0)))))
+    val shares = additionalProvider.fold(baseShares)(provider => baseShares + (provider._1 -> provider._2))
+    val feeShares = additionalProvider.foldLeft(Map(owner -> 0L.toNonNegLongUnsafe)) {
+      case (acc, (addr, _)) => acc + (addr -> 0L.toNonNegLongUnsafe)
+    }
+
+    val totalShares = shares.values.map(_.value.value.value).sum.toPosLongUnsafe
+
+    val liquidityPool = LiquidityPool(
+      poolId,
+      tokenA,
+      tokenB,
+      owner,
+      BigInt(tokenA.amount.value) * BigInt(tokenB.amount.value),
+      PoolShares(totalShares, shares, Map.empty, feeShares),
+      fees
+    )
+    (
+      poolId.value,
+      LiquidityPoolCalculatedState.empty.copy(confirmed =
+        ConfirmedLiquidityPoolCalculatedState.empty.copy(value = Map(poolId.value -> liquidityPool))
+      )
+    )
+  }
+
+  def toFixedPoint(decimal: Double): Long = (decimal * 1e8).toLong
+}

--- a/modules/l0/src/test/scala/org/amm_metagraph/l0/routes/LiquidityPoolRoutesSpec.scala
+++ b/modules/l0/src/test/scala/org/amm_metagraph/l0/routes/LiquidityPoolRoutesSpec.scala
@@ -1,0 +1,112 @@
+package org.amm_metagraph.l0.routes
+
+import cats.Eq
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.swap.CurrencyId
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
+
+import eu.timepit.refined.auto._
+import org.amm_metagraph.l0.Shared._
+import org.amm_metagraph.l0.custom_routes.LiquidityPoolRoutes
+import org.amm_metagraph.l0.custom_routes.Pagination.PaginationParams
+import org.amm_metagraph.shared_data.calculated_state.CalculatedStateService
+import org.amm_metagraph.shared_data.services.pricing.PricingService
+import org.amm_metagraph.shared_data.types.LiquidityPool._
+import org.amm_metagraph.shared_data.types.States._
+import org.amm_metagraph.shared_data.types.codecs
+import weaver.MutableIOSuite
+
+object LiquidityPoolRoutesSpec extends MutableIOSuite {
+  type Res = (Hasher[IO], codecs.HasherSelector[IO], SecurityProvider[IO])
+
+  override def sharedResource: Resource[IO, Res] = for {
+    sp <- SecurityProvider.forAsync[IO]
+    implicit0(j: JsonSerializer[IO]) <- JsonSerializer.forSync[IO].asResource
+    h = Hasher.forJson[IO]
+    hs = codecs.HasherSelector.forSync(h, h)
+  } yield (h, hs, sp)
+
+  implicit val eqDataApplicationValidationErrorOr: Eq[DataApplicationValidationErrorOr[Unit]] =
+    Eq.fromUniversalEquals
+
+  test("Should get all LP correctly") { implicit res =>
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
+    val ownerAddress = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
+
+    val (_, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress)
+    val ammCalculatedState = AmmCalculatedState(
+      Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
+    )
+
+    for {
+      calculatedStateService <- CalculatedStateService.make[IO]
+      _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, ammCalculatedState)
+      pricingService = PricingService.make[IO](config, calculatedStateService)
+      liquidityPoolRoutes = LiquidityPoolRoutes(calculatedStateService, pricingService)
+      paginationParams = PaginationParams(10, 0)
+      (liquidityPools, _) <- liquidityPoolRoutes.getLiquidityPools(paginationParams, none)
+    } yield
+      expect.all(
+        liquidityPools.size === 1,
+        liquidityPools.head.poolId === liquidityPoolCalculatedState.confirmed.value.head._2.poolId.value
+      )
+  }
+
+  test("Should return empty pools when provided address don't have shares") { implicit res =>
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
+    val ownerAddress = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
+
+    val (_, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress)
+    val ammCalculatedState = AmmCalculatedState(
+      Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
+    )
+
+    for {
+      calculatedStateService <- CalculatedStateService.make[IO]
+      _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, ammCalculatedState)
+      pricingService = PricingService.make[IO](config, calculatedStateService)
+      liquidityPoolRoutes = LiquidityPoolRoutes(calculatedStateService, pricingService)
+      paginationParams = PaginationParams(10, 0)
+      (liquidityPools, _) <- liquidityPoolRoutes.getLiquidityPools(
+        paginationParams,
+        Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb").some
+      )
+    } yield
+      expect.all(
+        liquidityPools.isEmpty
+      )
+  }
+
+  test("Should return LP when provided address have shares") { implicit res =>
+    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
+    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
+    val ownerAddress = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
+
+    val (_, liquidityPoolCalculatedState) = buildLiquidityPoolCalculatedState(primaryToken, pairToken, ownerAddress)
+    val ammCalculatedState = AmmCalculatedState(
+      Map(OperationType.LiquidityPool -> liquidityPoolCalculatedState)
+    )
+
+    for {
+      calculatedStateService <- CalculatedStateService.make[IO]
+      _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, ammCalculatedState)
+      pricingService = PricingService.make[IO](config, calculatedStateService)
+      liquidityPoolRoutes = LiquidityPoolRoutes(calculatedStateService, pricingService)
+      paginationParams = PaginationParams(10, 0)
+      (liquidityPools, _) <- liquidityPoolRoutes.getLiquidityPools(paginationParams, ownerAddress.some)
+    } yield
+      expect.all(
+        liquidityPools.size === 1,
+        liquidityPools.head.poolId === liquidityPoolCalculatedState.confirmed.value.head._2.poolId.value
+      )
+  }
+}

--- a/modules/shared_data/src/test/scala/com/my/amm_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/amm_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -14,9 +14,9 @@ import io.constellationnetwork.schema.artifact.SpendAction
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops.PublicKeyOps
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvider}
-import io.constellationnetwork.security.key.ops.PublicKeyOps
 
 import com.my.amm_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import com.my.amm_metagraph.shared_data.Shared._
@@ -966,7 +966,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
     val ammCalculatedState = AmmCalculatedState(Map.empty)
     val state = DataState(ammOnChainState, ammCalculatedState)
     val futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
-    
+
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpendTokenA = AllowSpend(
@@ -1046,7 +1046,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         CurrencyId(destinationAddress)
       )
 
-      liquidityPoolPendingSpendActionResponse2 <-  liquidityPoolCombinerService.combineNew(
+      liquidityPoolPendingSpendActionResponse2 <- liquidityPoolCombinerService.combineNew(
         liquidityPoolUpdate,
         liquidityPoolPendingSpendActionResponse,
         futureEpoch,
@@ -1054,7 +1054,9 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         CurrencyId(destinationAddress)
       )
 
-      lpCalculatedState = liquidityPoolPendingSpendActionResponse2.calculated.operations(LiquidityPool).asInstanceOf[LiquidityPoolCalculatedState]
+      lpCalculatedState = liquidityPoolPendingSpendActionResponse2.calculated
+        .operations(LiquidityPool)
+        .asInstanceOf[LiquidityPoolCalculatedState]
     } yield
       expect.all(
         lpCalculatedState.failed.toList.length === 1,
@@ -1064,6 +1066,5 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         lpCalculatedState.failed.toList.head.reason == DuplicatedAllowSpend(liquidityPoolUpdate)
       )
   }
-
 
 }

--- a/modules/shared_data/src/test/scala/com/my/amm_metagraph/shared_data/combiners/StakingCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/amm_metagraph/shared_data/combiners/StakingCombinerTest.scala
@@ -16,8 +16,8 @@ import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.security._
 import io.constellationnetwork.security.hash.Hash
-import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.key.ops.PublicKeyOps
+import io.constellationnetwork.security.signature.Signed
 
 import com.my.amm_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import com.my.amm_metagraph.shared_data.Shared._

--- a/modules/shared_data/src/test/scala/com/my/amm_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/com/my/amm_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -4,6 +4,7 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 
 import scala.collection.immutable.{SortedMap, SortedSet}
+
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.ext.cats.effect.ResourceIO
 import io.constellationnetwork.json.JsonSerializer
@@ -13,9 +14,10 @@ import io.constellationnetwork.schema.artifact.SpendAction
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.schema.swap._
 import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.key.ops.PublicKeyOps
 import io.constellationnetwork.security.signature.Signed
 import io.constellationnetwork.security.{Hasher, KeyPairGenerator, SecurityProvider}
-import io.constellationnetwork.security.key.ops.PublicKeyOps
+
 import com.my.amm_metagraph.shared_data.DummyL0Context.buildL0NodeContext
 import com.my.amm_metagraph.shared_data.Shared._
 import eu.timepit.refined.auto._
@@ -2238,6 +2240,5 @@ object SwapCombinerTest extends MutableIOSuite {
         swapCalculatedState.failed.toList.head.reason == DuplicatedAllowSpend(swapUpdate)
       )
   }
-
 
 }


### PR DESCRIPTION
### Changes
+ Adding address as a query param to search in LPs the pools that the address has shares in