### PR TITLE
feat: moving L0 validations to combine to save on failed state

### DIFF
--- a/.github/action_scripts/shared/api/calculated-state.ts
+++ b/.github/action_scripts/shared/api/calculated-state.ts
@@ -71,6 +71,7 @@ const getCalculatedState = async (
     ammL0Url: string,
 ): Promise<CalculatedState> => {
     const { data } = await axios.get(`${ammL0Url}/v1/calculated-state/latest`);
+    console.log(`TESTING CALCULATED STATE: ${JSON.stringify(data)}`)
     return data.calculatedState;
 }
 

--- a/modules/data_l1/src/main/scala/org/amm_metagraph/data_l1/Main.scala
+++ b/modules/data_l1/src/main/scala/org/amm_metagraph/data_l1/Main.scala
@@ -44,12 +44,12 @@ object Main
 
     config <- ApplicationConfigOps.readDefault[IO].asResource
 
-    liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    stakingValidations = StakingValidations.make[IO](config)
-    swapValidations = SwapValidations.make[IO](config)
-    withdrawalValidations = WithdrawalValidations.make[IO](config)
-    governanceValidations = GovernanceValidations.make[IO]
-    rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
+    liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+    stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+    swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+    withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+    governanceValidations = GovernanceValidations.make[IO](config)
+    rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
 
     validationService = ValidationService.make[IO](
       config,

--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/Main.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/Main.scala
@@ -54,12 +54,12 @@ object Main
     calculatedStateService <- CalculatedStateService.make[IO].asResource
     globalSnapshotsStorage: GlobalSnapshotsStorage[IO] <- GlobalSnapshotsStorage.make[IO].asResource
 
-    liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    stakingValidations = StakingValidations.make[IO](config)
-    swapValidations = SwapValidations.make[IO](config)
-    withdrawalValidations = WithdrawalValidations.make[IO](config)
-    governanceValidations = GovernanceValidations.make[IO]
-    rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
+    liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+    stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+    swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+    withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+    governanceValidations = GovernanceValidations.make[IO](config)
+    rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
 
     validationService = ValidationService.make[IO](
       config,
@@ -72,14 +72,14 @@ object Main
     )
 
     pricingService = PricingService.make[IO](config, calculatedStateService)
-    governanceCombinerService = GovernanceCombinerService.make[IO](config)
+    governanceCombinerService = GovernanceCombinerService.make[IO](config, governanceValidations)
     liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
     stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
     swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
     withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
     rewardsCalculator = RewardCalculator.make[IO](config.rewards, config.epochInfo)
     rewardsCombinerService = RewardsDistributionService.make[IO](rewardsCalculator, config.rewards)
-    rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards)
+    rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards, rewardWithdrawValidations)
 
     combinerService = L0CombinerService
       .make[IO](

--- a/modules/l0/src/main/scala/org/amm_metagraph/l0/rewards/RewardsService.scala
+++ b/modules/l0/src/main/scala/org/amm_metagraph/l0/rewards/RewardsService.scala
@@ -23,12 +23,10 @@ import org.amm_metagraph.shared_data.types.States.AmmCalculatedState
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-/**
- * Rewards created by RewardWithdrawUpdate by moving from
- * calculatedState.rewards.availableRewards to calculatedState.rewards.withdraws.pending
- * RewardsService create rewards based on "pending" data for current epoch.
- * Clearance of pending state is done in RewardWithdrawService
- */
+/** Rewards created by RewardWithdrawUpdate by moving from calculatedState.rewards.availableRewards to
+  * calculatedState.rewards.withdraws.pending RewardsService create rewards based on "pending" data for current epoch. Clearance of pending
+  * state is done in RewardWithdrawService
+  */
 object RewardsService {
   def make[F[_]: Async: SecurityProvider]: Rewards[F, CurrencySnapshotStateProof, CurrencyIncrementalSnapshot, CurrencySnapshotEvent] = {
     def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("RewardsWithdrawService")

--- a/modules/shared_data/src/main/resources/application.conf
+++ b/modules/shared_data/src/main/resources/application.conf
@@ -4,8 +4,8 @@ min-tokens-liquidity-pool = 10000000000
 allow-spend-epoch-buffer-delay = 5
 
 expiration-epoch-progresses {
-    confirmed-operations = 30
-    failed-operations = 30
+    confirmed-operations = 5
+    failed-operations = 5
 }
 
 token-limits {

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/L0CombinerService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/L0CombinerService.scala
@@ -134,7 +134,8 @@ object L0CombinerService {
                       rewardsWithdrawService.combineNew(
                         Signed(rewardWithdrawUpdate, signedUpdate.proofs),
                         acc,
-                        currentSnapshotEpochProgress
+                        currentSnapshotEpochProgress,
+                        lastSyncGlobalEpochProgress
                       )
                 }
               } yield combinedState

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/RewardsWithdrawService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/services/combiners/RewardsWithdrawService.scala
@@ -3,10 +3,12 @@ package org.amm_metagraph.shared_data.services.combiners
 import cats.data.EitherT
 import cats.effect.Async
 import cats.syntax.all._
-import eu.timepit.refined.types.numeric.NonNegLong
+
 import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
 import io.constellationnetwork.schema.epoch.EpochProgress
 import io.constellationnetwork.security.signature.Signed
+
+import eu.timepit.refined.types.numeric.NonNegLong
 import monocle.syntax.all._
 import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.refined._
@@ -16,6 +18,7 @@ import org.amm_metagraph.shared_data.types.Rewards.RewardInfo
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.codecs.HasherSelector
 import org.amm_metagraph.shared_data.validations.Errors._
+import org.amm_metagraph.shared_data.validations.RewardWithdrawValidations
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -23,24 +26,29 @@ trait RewardsWithdrawService[F[_]] {
   def combineNew(
     signedUpdate: Signed[RewardWithdrawUpdate],
     oldState: DataState[AmmOnChainState, AmmCalculatedState],
+    currentMetagraphEpochProgress: EpochProgress,
     globalEpochProgress: EpochProgress
   )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]]
 }
 
 object RewardsWithdrawService {
-  def make[F[_]: Async: HasherSelector](rewardsConfig: ApplicationConfig.Rewards): RewardsWithdrawService[F] =
+  def make[F[_]: Async: HasherSelector](
+    rewardsConfig: ApplicationConfig.Rewards,
+    rewardWithdrawValidation: RewardWithdrawValidations[F]
+  ): RewardsWithdrawService[F] =
     new RewardsWithdrawService[F] {
       def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("RewardsWithdrawService")
-      //Actual reward distribution done in Rewards Service.
-      //Reward Service can't remove already distributed rewards because it can't change state directly.
-      //Thus, we shall clear it here by assuming that rewards had been distributed already and we no longer
-      //need information in Rewards Pending Calculated state about rewards "pendingClearDelay" epochs ago
+      // Actual reward distribution done in Rewards Service.
+      // Reward Service can't remove already distributed rewards because it can't change state directly.
+      // Thus, we shall clear it here by assuming that rewards had been distributed already and we no longer
+      // need information in Rewards Pending Calculated state about rewards "pendingClearDelay" epochs ago
       private val pendingClearDelay = EpochProgress(NonNegLong(10L))
 
       override def combineNew(
         withdrawRequest: Signed[RewardWithdrawUpdate],
         oldState: DataState[AmmOnChainState, AmmCalculatedState],
-        currentEpoch: EpochProgress
+        currentMetagraphEpochProgress: EpochProgress,
+        globalEpochProgress: EpochProgress
       )(implicit context: L0NodeContext[F]): F[DataState[AmmOnChainState, AmmCalculatedState]] = {
         val rewardsState = oldState.calculated.rewards
         val calculatedState: RewardWithdrawCalculatedState = rewardsState.withdraws
@@ -49,14 +57,21 @@ object RewardsWithdrawService {
 
         val combinedState: EitherT[F, FailedCalculatedState, DataState[AmmOnChainState, AmmCalculatedState]] =
           for {
+            _ <- EitherT(
+              rewardWithdrawValidation.rewardWithdrawValidationL0(
+                withdrawRequest,
+                oldState.calculated,
+                globalEpochProgress
+              )
+            )
             _ <- EitherT.liftF(logger.info(show"Received reward withdrawn request: ${withdrawRequest.value}"))
-            withdrawEpoch <- calculateWithdrawEpoch(currentEpoch, withdrawRequest)
+            withdrawEpoch <- calculateWithdrawEpoch(currentMetagraphEpochProgress, withdrawRequest)
 
-            removeFromPending = currentEpoch.minus(pendingClearDelay).getOrElse(EpochProgress.MinValue)
+            removeFromPending = currentMetagraphEpochProgress.minus(pendingClearDelay).getOrElse(EpochProgress.MinValue)
             clearedPending = calculatedState.pending.removed(removeFromPending) // clear already distributed rewards
             pendingWithdraws = clearedPending.getOrElse(withdrawEpoch, RewardInfo.empty)
             (newAvailableRewards, newPendingRewards) <-
-              moveAvailableToPending(currentEpoch, availableRewards, pendingWithdraws, withdrawRequest)
+              moveAvailableToPending(currentMetagraphEpochProgress, availableRewards, pendingWithdraws, withdrawRequest)
             newPending = clearedPending + (withdrawEpoch -> newPendingRewards)
 
             reference <- EitherT.liftF(HasherSelector[F].withCurrent(implicit hs => RewardWithdrawReference.of(withdrawRequest)))

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/Errors.scala
@@ -192,7 +192,19 @@ object Errors {
   case class MissingSwapTokenInfo() extends FailedCalculatedStateReason
   case class MissingWithdrawalsAmount() extends FailedCalculatedStateReason
   case class InvalidCurrencyIdsBetweenAllowSpendsAndDataUpdate(update: AmmUpdate) extends FailedCalculatedStateReason
-  case class InvalidAddressRewardType(address: Address, rewardType: RewardType) extends FailedCalculatedStateReason
   case object WrongRewardWithdrawEpoch extends FailedCalculatedStateReason
   case class RewardWithdrawAmountError(currentAmount: Amount, error: String) extends FailedCalculatedStateReason
+
+  case class InvalidSignatures(messages: String) extends FailedCalculatedStateReason
+  case class TransactionAlreadyExists(update: AmmUpdate) extends FailedCalculatedStateReason
+  case class InvalidLastReference() extends FailedCalculatedStateReason
+  case class NotEnoughShares() extends FailedCalculatedStateReason
+  case class NotEnoughTokens() extends FailedCalculatedStateReason
+  case class WithdrawalAllLPSharesError() extends FailedCalculatedStateReason
+  case class WithdrawalNotPendingError() extends FailedCalculatedStateReason
+  case class GovernanceDailyLimitAllocation(update: AmmUpdate) extends FailedCalculatedStateReason
+  case class GovernanceWalletWithNoVotingWeight(update: AmmUpdate) extends FailedCalculatedStateReason
+  case class GovernanceInvalidVoteId(update: AmmUpdate) extends FailedCalculatedStateReason
+  case class InvalidWithdrawalAmount(update: AmmUpdate) extends FailedCalculatedStateReason
+  case class DuplicatedUpdate(update: AmmUpdate) extends FailedCalculatedStateReason
 }

--- a/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
+++ b/modules/shared_data/src/main/scala/org/amm_metagraph/shared_data/validations/ValidationService.scala
@@ -13,6 +13,7 @@ import org.amm_metagraph.shared_data.app.ApplicationConfig
 import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.codecs.HasherSelector
+import org.amm_metagraph.shared_data.validations.Errors.valid
 import org.amm_metagraph.shared_data.validations.SharedValidations.validateAmmMetagraphId
 
 trait ValidationService[F[_]] {
@@ -46,7 +47,7 @@ object ValidationService {
           case stakingUpdate: StakingUpdate       => stakingValidations.l1Validations(stakingUpdate)
           case withdrawalUpdate: WithdrawalUpdate => withdrawalValidations.l1Validations(withdrawalUpdate)
           case liquidityPoolUpdate: LiquidityPoolUpdate =>
-            liquidityPoolValidations.l1Validations(applicationConfig, liquidityPoolUpdate)
+            liquidityPoolValidations.l1Validations(liquidityPoolUpdate)
           case swapUpdate: SwapUpdate => swapValidations.l1Validations(swapUpdate)
           case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate =>
             governanceValidations.l1Validations(rewardAllocationVoteUpdate)
@@ -57,37 +58,12 @@ object ValidationService {
         result
           .productR(ammMetagraphIdV)
 
+      // The validations were migrated to combine function to populate FailedOperations state
       private def validateL0(
         signedUpdate: Signed[AmmUpdate],
         state: AmmCalculatedState
       )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-        for {
-          lastSyncGlobalSnapshot <- OptionT(context.getLastSynchronizedGlobalSnapshot).getOrRaise(
-            new IllegalStateException("lastSyncGlobalSnapshot unavailable")
-          )
-          ammMetagraphId <- context.getCurrencyId
-          ammMetagraphIdV = validateAmmMetagraphId(signedUpdate.value, ammMetagraphId)
-
-          result <- signedUpdate.value match {
-            case stakingUpdate: StakingUpdate => stakingValidations.l0Validations(Signed(stakingUpdate, signedUpdate.proofs), state)
-            case withdrawalUpdate: WithdrawalUpdate =>
-              withdrawalValidations.l0Validations(Signed(withdrawalUpdate, signedUpdate.proofs), state)
-            case liquidityPoolUpdate: LiquidityPoolUpdate =>
-              liquidityPoolValidations.l0Validations(applicationConfig, Signed(liquidityPoolUpdate, signedUpdate.proofs), state)
-            case swapUpdate: SwapUpdate => swapValidations.l0Validations(Signed(swapUpdate, signedUpdate.proofs), state)
-            case rewardAllocationVoteUpdate: RewardAllocationVoteUpdate =>
-              governanceValidations.l0Validations(
-                applicationConfig,
-                Signed(rewardAllocationVoteUpdate, signedUpdate.proofs),
-                state,
-                lastSyncGlobalSnapshot.epochProgress
-              )
-            case rewardWithdrawUpdate: RewardWithdrawUpdate =>
-              rewardWithdrawValidations.rewardWithdrawValidationL0(Signed(rewardWithdrawUpdate, signedUpdate.proofs), state)
-          }
-        } yield
-          result
-            .productR(ammMetagraphIdV)
+        valid.pure
 
       override def validateUpdate(
         update: AmmUpdate

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/DummyL0Context.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/DummyL0Context.scala
@@ -70,6 +70,7 @@ object DummyL0Context {
       none,
       none,
       none,
+      none,
       none
     )
 

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/CombinerTest.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/CombinerTest.scala
@@ -130,20 +130,22 @@ object CombinerTest extends MutableIOSuite {
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
       globalSnapshotService <- GlobalSnapshotsStorage.make[IO]
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-      stakingValidations = StakingValidations.make[IO](config)
-      swapValidations = SwapValidations.make[IO](config)
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardsValidations = RewardWithdrawValidations.make[IO](config)
 
       pricingService = PricingService.make[IO](config, calculatedStateService)
-      governanceCombinerService = GovernanceCombinerService.make[IO](config)
+      governanceCombinerService = GovernanceCombinerService.make[IO](config, governanceValidations)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
       rewardsCombinerService = RewardsDistributionService
         .make[IO](RewardCalculator.make[IO](config.rewards, config.epochInfo), config.rewards)
-      rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards)
+      rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards, rewardsValidations)
 
       combinerService = L0CombinerService
         .make[IO](
@@ -276,14 +278,15 @@ object CombinerTest extends MutableIOSuite {
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
       globalSnapshotService <- GlobalSnapshotsStorage.make[IO]
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-      stakingValidations = StakingValidations.make[IO](config)
-      swapValidations = SwapValidations.make[IO](config)
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
-      governanceValidations = GovernanceValidations.make[IO]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardsValidations = RewardWithdrawValidations.make[IO](config)
 
       pricingService = PricingService.make[IO](config, calculatedStateService)
-      governanceCombinerService = GovernanceCombinerService.make[IO](config)
+      governanceCombinerService = GovernanceCombinerService.make[IO](config, governanceValidations)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
@@ -291,7 +294,7 @@ object CombinerTest extends MutableIOSuite {
 
       rewardsCombinerService = RewardsDistributionService
         .make[IO](RewardCalculator.make[IO](config.rewards, config.epochInfo), config.rewards)
-      rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards)
+      rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards, rewardsValidations)
 
       combinerService = L0CombinerService
         .make[IO](
@@ -433,20 +436,22 @@ object CombinerTest extends MutableIOSuite {
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
       globalSnapshotService <- GlobalSnapshotsStorage.make[IO]
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-      stakingValidations = StakingValidations.make[IO](config)
-      swapValidations = SwapValidations.make[IO](config)
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardsValidations = RewardWithdrawValidations.make[IO](config)
 
       pricingService = PricingService.make[IO](config, calculatedStateService)
-      governanceCombinerService = GovernanceCombinerService.make[IO](config)
+      governanceCombinerService = GovernanceCombinerService.make[IO](config, governanceValidations)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
       rewardsCombinerService = RewardsDistributionService
         .make[IO](RewardCalculator.make[IO](config.rewards, config.epochInfo), config.rewards)
-      rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards)
+      rewardsWithdrawService = RewardsWithdrawService.make[IO](config.rewards, rewardsValidations)
 
       combinerService = L0CombinerService
         .make[IO](

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/LiquidityPoolCombinerTest.scala
@@ -129,8 +129,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         destinationAddress
       )
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolPendingSpendActionResponse <- liquidityPoolCombinerService.combineNew(
@@ -252,8 +252,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         ownerAddress
       )
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolPendingSpendActionResponse <- liquidityPoolCombinerService.combineNew(
@@ -381,8 +381,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         ownerAddress
       )
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolResponse <- liquidityPoolCombinerService.combineNew(
@@ -491,8 +491,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         SnapshotOrdinal.MinValue,
         destinationAddress
       )
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolResponse <- liquidityPoolCombinerService.combineNew(
@@ -605,8 +605,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         destinationAddress
       )
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolResponse <- liquidityPoolCombinerService.combineNew(
@@ -623,7 +623,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         liquidityPoolCalculatedState.failed.toList.head.expiringEpochProgress === EpochProgress(
           NonNegLong.unsafeFrom(futureEpoch.value.value + config.expirationEpochProgresses.failedOperations.value.value)
         ),
-        liquidityPoolCalculatedState.failed.toList.head.reason == DuplicatedLiquidityPoolRequest(liquidityPoolUpdate)
+        liquidityPoolCalculatedState.failed.toList.head.reason == InvalidLiquidityPool()
       )
   }
 
@@ -711,8 +711,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolPendingSpendActionResponse <- liquidityPoolCombinerService.combineNew(
@@ -820,7 +820,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
       )
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
       liquidityPoolResponse <- liquidityPoolCombinerService.combineNew(
         liquidityPoolUpdate,
@@ -924,8 +924,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         destinationAddress
       )
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
@@ -1011,6 +1011,20 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
           None
         )
       )
+      liquidityPoolUpdate2 = getFakeSignedUpdate(
+        LiquidityPoolUpdate(
+          CurrencyId(destinationAddress),
+          sourceAddress,
+          signedAllowSpendA.hash,
+          signedAllowSpendB.hash,
+          tokenAId,
+          tokenBId,
+          tokenAAmount,
+          tokenBAmount,
+          EpochProgress.MinValue,
+          None
+        )
+      )
 
       allowSpends = SortedMap(
         tokenAId.get.value.some ->
@@ -1034,8 +1048,8 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         destinationAddress
       )
 
-      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
       liquidityPoolCombinerService = LiquidityPoolCombinerService.make[IO](liquidityPoolValidations, jsonBase64BinaryCodec)
 
       liquidityPoolPendingSpendActionResponse <- liquidityPoolCombinerService.combineNew(
@@ -1047,7 +1061,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
       )
 
       liquidityPoolPendingSpendActionResponse2 <- liquidityPoolCombinerService.combineNew(
-        liquidityPoolUpdate,
+        liquidityPoolUpdate2,
         liquidityPoolPendingSpendActionResponse,
         futureEpoch,
         allowSpends,
@@ -1063,7 +1077,7 @@ object LiquidityPoolCombinerTest extends MutableIOSuite {
         lpCalculatedState.failed.toList.head.expiringEpochProgress === EpochProgress(
           NonNegLong.unsafeFrom(futureEpoch.value.value + config.expirationEpochProgresses.failedOperations.value.value)
         ),
-        lpCalculatedState.failed.toList.head.reason == DuplicatedAllowSpend(liquidityPoolUpdate)
+        lpCalculatedState.failed.toList.head.reason == InvalidLiquidityPool()
       )
   }
 

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/StakingCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/StakingCombinerTest.scala
@@ -144,8 +144,8 @@ object StakingCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponsePendingSpendActionResponse <- stakingCombinerService.combineNew(
@@ -290,8 +290,8 @@ object StakingCombinerTest extends MutableIOSuite {
       calculatedStateService <- CalculatedStateService.make[IO]
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponsePendingSpendActionResponse <- stakingCombinerService.combineNew(
@@ -426,8 +426,8 @@ object StakingCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponse <- stakingCombinerService.combineNew(
@@ -543,8 +543,8 @@ object StakingCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponse <- stakingCombinerService.combineNew(
@@ -634,6 +634,19 @@ object StakingCombinerTest extends MutableIOSuite {
         )
       )
 
+      stakingUpdate2 = getFakeSignedUpdate(
+        StakingUpdate(
+          CurrencyId(destinationAddress),
+          sourceAddress,
+          signedAllowSpendA.hash,
+          signedAllowSpendB.hash,
+          primaryToken.identifier,
+          PosLong.unsafeFrom(toFixedPoint(10.0)),
+          pairToken.identifier,
+          StakingReference.empty,
+          futureEpoch
+        )
+      )
       allowSpends = SortedMap(
         primaryToken.identifier.get.value.some ->
           SortedMap(
@@ -659,8 +672,8 @@ object StakingCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponsePendingSpendActionResponse <- stakingCombinerService.combineNew(
@@ -672,7 +685,7 @@ object StakingCombinerTest extends MutableIOSuite {
       )
 
       stakeResponsePendingSpendActionResponse2 <- stakingCombinerService.combineNew(
-        stakingUpdate,
+        stakingUpdate2,
         stakeResponsePendingSpendActionResponse,
         futureEpoch,
         allowSpends,
@@ -686,7 +699,7 @@ object StakingCombinerTest extends MutableIOSuite {
         stakingCalculatedState.failed.toList.head.expiringEpochProgress === EpochProgress(
           NonNegLong.unsafeFrom(futureEpoch.value.value + config.expirationEpochProgresses.failedOperations.value.value)
         ),
-        stakingCalculatedState.failed.toList.head.reason == DuplicatedAllowSpend(stakingUpdate)
+        stakingCalculatedState.failed.toList.head.reason == TransactionAlreadyExists(stakingUpdate2)
       )
   }
 
@@ -788,7 +801,7 @@ object StakingCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      stakingValidations = StakingValidations.make[IO](config.copy(allowSpendEpochBufferDelay = bufferDelay))
+      stakingValidations = StakingValidations.make[IO](config.copy(allowSpendEpochBufferDelay = bufferDelay), jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
       stakeResponse <- stakingCombinerService.combineNew(
         stakingUpdate,
@@ -902,8 +915,8 @@ object StakingCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponsePendingSpendActionResponse <- stakingCombinerService.combineNew(
@@ -1049,8 +1062,8 @@ object StakingCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
-      stakingValidations = StakingValidations.make[IO](config)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
       stakingCombinerService = StakingCombinerService.make[IO](config, pricingService, stakingValidations, jsonBase64BinaryCodec)
 
       stakeResponsePendingSpendActionResponse <- stakingCombinerService.combineNew(

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/SwapCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/SwapCombinerTest.scala
@@ -74,7 +74,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -91,7 +91,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -125,7 +125,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -151,7 +151,7 @@ object SwapCombinerTest extends MutableIOSuite {
       )
 
       swapCalculatedState = swapConfirmedResponse.calculated.operations(OperationType.Swap).asInstanceOf[SwapCalculatedState]
-      addressSwapResponse = swapCalculatedState.confirmed.value(sourceAddress).values.head.value
+      addressSwapResponse = swapCalculatedState.confirmed.value(ownerAddress).values.head.value
 
       oldLiquidityPoolCalculatedState = state.calculated
         .operations(OperationType.LiquidityPool)
@@ -200,7 +200,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -217,7 +217,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -251,7 +251,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -330,7 +330,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -347,7 +347,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -381,7 +381,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapResponse <- swapCombinerService.combineNew(
@@ -466,7 +466,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapResponse <- swapCombinerService.combineNew(
@@ -552,7 +552,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -608,7 +608,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -625,7 +625,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -659,7 +659,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -685,7 +685,7 @@ object SwapCombinerTest extends MutableIOSuite {
       )
 
       swapCalculatedState = swapConfirmedResponse.calculated.operations(OperationType.Swap).asInstanceOf[SwapCalculatedState]
-      addressSwapResponse = swapCalculatedState.confirmed.value(sourceAddress).values.head.value
+      addressSwapResponse = swapCalculatedState.confirmed.value(ownerAddress).values.head.value
 
       oldLiquidityPoolCalculatedState = state.calculated
         .operations(OperationType.LiquidityPool)
@@ -781,7 +781,7 @@ object SwapCombinerTest extends MutableIOSuite {
       for {
         keyPair <- KeyPairGenerator.makeKeyPair[IO]
         allowSpend = AllowSpend(
-          sourceAddress,
+          ownerAddress,
           destinationAddress,
           primaryToken.identifier,
           SwapAmount(PosLong.MaxValue),
@@ -798,7 +798,7 @@ object SwapCombinerTest extends MutableIOSuite {
         swapUpdate = getFakeSignedUpdate(
           SwapUpdate(
             CurrencyId(destinationAddress),
-            sourceAddress,
+            ownerAddress,
             primaryToken.identifier,
             pairToken.identifier,
             signedAllowSpend.hash,
@@ -813,7 +813,7 @@ object SwapCombinerTest extends MutableIOSuite {
         allowSpends = SortedMap(
           primaryToken.identifier.get.value.some ->
             SortedMap(
-              sourceAddress -> SortedSet(signedAllowSpend.signed)
+              ownerAddress -> SortedSet(signedAllowSpend.signed)
             )
         )
 
@@ -832,7 +832,7 @@ object SwapCombinerTest extends MutableIOSuite {
         _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
         pricingService = PricingService.make[IO](config, calculatedStateService)
         jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-        swapValidations = SwapValidations.make[IO](config)
+        swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
         swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
         swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -916,7 +916,7 @@ object SwapCombinerTest extends MutableIOSuite {
       for {
         keyPair <- KeyPairGenerator.makeKeyPair[IO]
         allowSpend = AllowSpend(
-          sourceAddress,
+          ownerAddress,
           destinationAddress,
           pairToken.identifier,
           SwapAmount(PosLong.MaxValue),
@@ -933,7 +933,7 @@ object SwapCombinerTest extends MutableIOSuite {
         swapUpdate = getFakeSignedUpdate(
           SwapUpdate(
             CurrencyId(destinationAddress),
-            sourceAddress,
+            ownerAddress,
             pairToken.identifier,
             primaryToken.identifier,
             signedAllowSpend.hash,
@@ -948,7 +948,7 @@ object SwapCombinerTest extends MutableIOSuite {
         allowSpends = SortedMap(
           pairToken.identifier.get.value.some ->
             SortedMap(
-              sourceAddress -> SortedSet(signedAllowSpend.signed)
+              ownerAddress -> SortedSet(signedAllowSpend.signed)
             )
         )
 
@@ -967,7 +967,7 @@ object SwapCombinerTest extends MutableIOSuite {
         _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
         pricingService = PricingService.make[IO](config, calculatedStateService)
         jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-        swapValidations = SwapValidations.make[IO](config)
+        swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
         swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
         swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1062,7 +1062,7 @@ object SwapCombinerTest extends MutableIOSuite {
         for {
           keyPair <- KeyPairGenerator.makeKeyPair[IO]
           allowSpend = AllowSpend(
-            sourceAddress,
+            ownerAddress,
             destinationAddress,
             primaryToken.identifier,
             SwapAmount(PosLong.MaxValue),
@@ -1079,7 +1079,7 @@ object SwapCombinerTest extends MutableIOSuite {
           swapUpdate = getFakeSignedUpdate(
             SwapUpdate(
               CurrencyId(destinationAddress),
-              sourceAddress,
+              ownerAddress,
               primaryToken.identifier,
               pairToken.identifier,
               signedAllowSpend.hash,
@@ -1094,7 +1094,7 @@ object SwapCombinerTest extends MutableIOSuite {
           allowSpends = SortedMap(
             primaryToken.identifier.get.value.some ->
               SortedMap(
-                sourceAddress -> SortedSet(signedAllowSpend.signed)
+                ownerAddress -> SortedSet(signedAllowSpend.signed)
               )
           )
 
@@ -1113,7 +1113,7 @@ object SwapCombinerTest extends MutableIOSuite {
           _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
           pricingService = PricingService.make[IO](config, calculatedStateService)
           jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-          swapValidations = SwapValidations.make[IO](config)
+          swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
           swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
           swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1233,7 +1233,7 @@ object SwapCombinerTest extends MutableIOSuite {
         for {
           keyPair <- KeyPairGenerator.makeKeyPair[IO]
           allowSpend = AllowSpend(
-            sourceAddress,
+            ownerAddress,
             destinationAddress,
             tokenB.identifier,
             SwapAmount(PosLong.MaxValue),
@@ -1250,7 +1250,7 @@ object SwapCombinerTest extends MutableIOSuite {
           swapUpdate = getFakeSignedUpdate(
             SwapUpdate(
               CurrencyId(destinationAddress),
-              sourceAddress,
+              ownerAddress,
               tokenB.identifier,
               tokenA.identifier,
               signedAllowSpend.hash,
@@ -1283,7 +1283,7 @@ object SwapCombinerTest extends MutableIOSuite {
           _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
           pricingService = PricingService.make[IO](config, calculatedStateService)
           jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-          swapValidations = SwapValidations.make[IO](config)
+          swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
           swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
           swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1384,7 +1384,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -1401,7 +1401,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -1435,7 +1435,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1508,11 +1508,19 @@ object SwapCombinerTest extends MutableIOSuite {
             case (accState, accExpectations) =>
               val swapAmount = 100.0 * i
               val fixedSwapAmount = toFixedPoint(swapAmount)
+              val lastRef = accState.calculated.operations
+                .get(OperationType.Swap)
+                .map {
+                  case SwapCalculatedState(confirmed, _, _) =>
+                    confirmed.value.get(ownerAddress).map(_.lastReference).getOrElse(SwapReference.empty)
+                  case _ => SwapReference.empty
+                }
+                .getOrElse(SwapReference.empty)
 
               for {
                 keyPair <- KeyPairGenerator.makeKeyPair[IO]
                 allowSpend = AllowSpend(
-                  sourceAddress,
+                  ownerAddress,
                   destinationAddress,
                   primaryToken.identifier,
                   SwapAmount(PosLong.from(toFixedPoint(1000.0) - i).getOrElse(PosLong.MaxValue)),
@@ -1529,7 +1537,7 @@ object SwapCombinerTest extends MutableIOSuite {
                 swapUpdate = getFakeSignedUpdate(
                   SwapUpdate(
                     CurrencyId(destinationAddress),
-                    sourceAddress,
+                    ownerAddress,
                     primaryToken.identifier,
                     pairToken.identifier,
                     signedAllowSpend.hash,
@@ -1537,14 +1545,14 @@ object SwapCombinerTest extends MutableIOSuite {
                     SwapAmount(PosLong.MinValue),
                     none,
                     EpochProgress.MaxValue,
-                    SwapReference.empty
+                    lastRef
                   )
                 )
 
                 allowSpends = SortedMap(
                   primaryToken.identifier.get.value.some ->
                     SortedMap(
-                      sourceAddress -> SortedSet(signedAllowSpend.signed)
+                      ownerAddress -> SortedSet(signedAllowSpend.signed)
                     )
                 )
 
@@ -1563,7 +1571,7 @@ object SwapCombinerTest extends MutableIOSuite {
                 _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, accState.calculated)
                 pricingService = PricingService.make[IO](config, calculatedStateService)
                 jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-                swapValidations = SwapValidations.make[IO](config)
+                swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
                 swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
                 swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1575,7 +1583,7 @@ object SwapCombinerTest extends MutableIOSuite {
                 )
 
                 (updatedState, currentExpectations) <-
-                  if (i > 8) {
+                  if (i > 3) {
                     IO.pure(
                       (
                         swapPendingSpendActionResponse,
@@ -1658,7 +1666,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -1675,7 +1683,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -1711,7 +1719,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1824,7 +1832,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -1841,7 +1849,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -1875,7 +1883,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -1952,7 +1960,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -1969,7 +1977,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -2003,7 +2011,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
@@ -2075,7 +2083,7 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
@@ -2109,7 +2117,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -2160,7 +2168,7 @@ object SwapCombinerTest extends MutableIOSuite {
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       allowSpend = AllowSpend(
-        sourceAddress,
+        ownerAddress,
         destinationAddress,
         primaryToken.identifier,
         SwapAmount(PosLong.MaxValue),
@@ -2177,11 +2185,25 @@ object SwapCombinerTest extends MutableIOSuite {
       swapUpdate = getFakeSignedUpdate(
         SwapUpdate(
           CurrencyId(destinationAddress),
-          sourceAddress,
+          ownerAddress,
           primaryToken.identifier,
           pairToken.identifier,
           signedAllowSpend.hash,
           SwapAmount(PosLong.unsafeFrom(toFixedPoint(100.0))),
+          SwapAmount(PosLong.unsafeFrom(toFixedPoint(40.0))),
+          none,
+          EpochProgress.MaxValue,
+          SwapReference.empty
+        )
+      )
+      swapUpdate2 = getFakeSignedUpdate(
+        SwapUpdate(
+          CurrencyId(destinationAddress),
+          ownerAddress,
+          primaryToken.identifier,
+          pairToken.identifier,
+          signedAllowSpend.hash,
+          SwapAmount(PosLong.unsafeFrom(toFixedPoint(10.0))),
           SwapAmount(PosLong.unsafeFrom(toFixedPoint(40.0))),
           none,
           EpochProgress.MaxValue,
@@ -2211,7 +2233,7 @@ object SwapCombinerTest extends MutableIOSuite {
       _ <- calculatedStateService.update(SnapshotOrdinal.MinValue, state.calculated)
       pricingService = PricingService.make[IO](config, calculatedStateService)
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      swapValidations = SwapValidations.make[IO](config)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
       swapCombinerService = SwapCombinerService.make[IO](config, pricingService, swapValidations, jsonBase64BinaryCodec)
 
       swapPendingSpendActionResponse <- swapCombinerService.combineNew(
@@ -2223,7 +2245,7 @@ object SwapCombinerTest extends MutableIOSuite {
       )
 
       swapPendingSpendActionResponse2 <- swapCombinerService.combineNew(
-        swapUpdate,
+        swapUpdate2,
         swapPendingSpendActionResponse,
         futureEpoch,
         allowSpends,
@@ -2237,7 +2259,7 @@ object SwapCombinerTest extends MutableIOSuite {
         swapCalculatedState.failed.toList.head.expiringEpochProgress === EpochProgress(
           NonNegLong.unsafeFrom(futureEpoch.value.value + config.expirationEpochProgresses.failedOperations.value.value)
         ),
-        swapCalculatedState.failed.toList.head.reason == DuplicatedAllowSpend(swapUpdate)
+        swapCalculatedState.failed.toList.head.reason == TransactionAlreadyExists(swapUpdate2)
       )
   }
 

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/WithdrawalCombinerTest.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/combiners/WithdrawalCombinerTest.scala
@@ -138,7 +138,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       withdrawalResponsePendingSpendActionResponse <- withdrawalCombinerService.combineNew(
@@ -256,7 +256,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       withdrawalResponsePendingSpendActionResponse <- withdrawalCombinerService.combineNew(
@@ -344,7 +344,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       result <- withdrawalCombinerService
@@ -357,12 +357,10 @@ object WithdrawalCombinerTest extends MutableIOSuite {
         )
         .attempt
         .map {
-          case Left(e: IllegalStateException) =>
-            expect(e.getMessage === "Liquidity Pool does not exist")
           case Left(e) =>
             failure(s"Unexpected exception: $e")
-          case Right(_) =>
-            failure("Expected exception was not thrown")
+          case Right(state) =>
+            expect(state.calculated.operations(Withdrawal).failed.head.reason == InvalidLiquidityPool())
         }
     } yield result
   }
@@ -423,7 +421,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       withdrawalResponsePendingSpendActionResponse <- withdrawalCombinerService.combineNew(
@@ -513,7 +511,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       result <- withdrawalCombinerService
@@ -589,7 +587,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       withdrawalResponsePendingSpendActionResponse <- withdrawalCombinerService.combineNew(
@@ -698,7 +696,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       withdrawalResponsePendingSpendActionResponse <- withdrawalCombinerService.combineNew(
@@ -800,7 +798,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
@@ -881,7 +879,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
@@ -962,7 +960,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))
@@ -1043,7 +1041,7 @@ object WithdrawalCombinerTest extends MutableIOSuite {
       pricingService = PricingService.make[IO](config, calculatedStateService)
 
       jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
-      withdrawalValidations = WithdrawalValidations.make[IO](config)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
       withdrawalCombinerService = WithdrawalCombinerService.make[IO](config, pricingService, withdrawalValidations, jsonBase64BinaryCodec)
 
       futureEpoch = EpochProgress(NonNegLong.unsafeFrom(10L))

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/validations/LiquidityPoolValidationTest.scala
@@ -34,6 +34,9 @@ import org.amm_metagraph.shared_data.types.DataUpdates._
 import org.amm_metagraph.shared_data.types.LiquidityPool._
 import org.amm_metagraph.shared_data.types.States._
 import org.amm_metagraph.shared_data.types.codecs
+import org.amm_metagraph.shared_data.types.codecs.JsonWithBase64BinaryCodec
+import org.amm_metagraph.shared_data.validations.Errors._
+import org.amm_metagraph.shared_data.validations.SwapValidationTest.expect
 import org.amm_metagraph.shared_data.validations._
 import weaver.MutableIOSuite
 
@@ -105,24 +108,25 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       None
     )
 
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config,
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
-
     for {
+      jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
+
+      validationService = ValidationService.make[IO](
+        config,
+        liquidityPoolValidations,
+        stakingValidations,
+        swapValidations,
+        withdrawalValidations,
+        governanceValidations,
+        rewardWithdrawValidations
+      )
+
       response <- validationService.validateUpdate(liquidityPoolUpdate)(context)
     } yield expect.eql(Valid(()), response)
   }
@@ -149,24 +153,24 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       None
     )
 
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config,
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
-
     for {
+      jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
+
+      validationService = ValidationService.make[IO](
+        config,
+        liquidityPoolValidations,
+        stakingValidations,
+        swapValidations,
+        withdrawalValidations,
+        governanceValidations,
+        rewardWithdrawValidations
+      )
       response <- validationService.validateUpdate(liquidityPoolUpdate)(context)
     } yield {
       val expectedError = response match {
@@ -204,22 +208,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
 
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config,
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
@@ -231,6 +219,23 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
         EpochProgress.MinValue,
         SnapshotOrdinal.MinValue,
         ownerAddress
+      )
+      jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
+
+      validationService = ValidationService.make[IO](
+        config,
+        liquidityPoolValidations,
+        stakingValidations,
+        swapValidations,
+        withdrawalValidations,
+        governanceValidations,
+        rewardWithdrawValidations
       )
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
     } yield expect.eql(Valid(()), response)
@@ -261,22 +266,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
 
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config,
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
@@ -288,75 +277,28 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
         EpochProgress.MinValue,
         SnapshotOrdinal.MinValue,
         ownerAddress
+      )
+      jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
+
+      validationService = ValidationService.make[IO](
+        config,
+        liquidityPoolValidations,
+        stakingValidations,
+        swapValidations,
+        withdrawalValidations,
+        governanceValidations,
+        rewardWithdrawValidations
       )
       response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
     } yield expect.eql(Valid(()), response)
   }
 
-  test("Validate data fail - both tokens none") { implicit res =>
-    implicit val (h, hs, sp) = res
-
-    val primaryToken = TokenInformation(none, 100L)
-    val pairToken = TokenInformation(none, 50L)
-    val ammOnChainState = AmmOnChainState(SortedSet.empty, None)
-    val ammCalculatedState = AmmCalculatedState()
-    val state = DataState(ammOnChainState, ammCalculatedState)
-    val ownerAddress = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
-
-    val liquidityPoolUpdate = LiquidityPoolUpdate(
-      CurrencyId(ownerAddress),
-      sourceAddress,
-      Hash.empty,
-      Hash.empty,
-      primaryToken.identifier,
-      pairToken.identifier,
-      primaryToken.amount,
-      pairToken.amount,
-      EpochProgress.MaxValue,
-      None
-    )
-
-    val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
-
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config,
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
-    for {
-      keyPair <- KeyPairGenerator.makeKeyPair[IO]
-      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
-        keyPair,
-        SortedMap.empty,
-        EpochProgress.MinValue,
-        SnapshotOrdinal.MinValue,
-        SortedMap.empty,
-        EpochProgress.MinValue,
-        SnapshotOrdinal.MinValue,
-        ownerAddress
-      )
-      response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
-    } yield {
-      val expectedError = response match {
-        case Invalid(errors) if errors.exists(_.isInstanceOf[Errors.LiquidityPoolNotEnoughInformation.type]) =>
-          true
-        case _ =>
-          false
-      }
-      expect(expectedError)
-    }
-  }
   test("Validate data fail - pool already exists") { implicit res =>
     implicit val (h, hs, sp) = res
 
@@ -386,23 +328,6 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
 
     val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
 
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config,
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
-
     for {
       keyPair <- KeyPairGenerator.makeKeyPair[IO]
       implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
@@ -415,8 +340,18 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
         SnapshotOrdinal.MinValue,
         ownerAddress
       )
-      response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
-    } yield expect(response == Errors.LiquidityPoolAlreadyExists.invalidNec)
+      jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config, jsonBase64BinaryCodec)
+      response <- liquidityPoolValidations.l0Validations(fakeSignedUpdate, state.calculated, EpochProgress.MaxValue)
+    } yield
+      response match {
+        case Left(value) =>
+          value.reason match {
+            case InvalidLiquidityPool() => expect(true)
+            case _                      => expect(false)
+          }
+        case Right(_) => expect(false)
+      }
   }
 
   test("Validate update fail - fees as 0 on mainnet environment") { implicit res =>
@@ -441,81 +376,25 @@ object LiquidityPoolValidationTest extends MutableIOSuite {
       FeeDistributor.empty.some
     )
 
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config.copy(environment = Mainnet),
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
     for {
-      response <- validationService.validateUpdate(liquidityPoolUpdate)(context)
-    } yield expect(response == Errors.FeePercentageTotalMustBeGreaterThanZero.invalidNec)
-  }
+      jsonBase64BinaryCodec <- JsonWithBase64BinaryCodec.forSync[IO, AmmUpdate]
+      liquidityPoolValidations = LiquidityPoolValidations.make[IO](config.copy(environment = Mainnet), jsonBase64BinaryCodec)
+      stakingValidations = StakingValidations.make[IO](config, jsonBase64BinaryCodec)
+      swapValidations = SwapValidations.make[IO](config, jsonBase64BinaryCodec)
+      withdrawalValidations = WithdrawalValidations.make[IO](config, jsonBase64BinaryCodec)
+      governanceValidations = GovernanceValidations.make[IO](config)
+      rewardWithdrawValidations = RewardWithdrawValidations.make[IO](config)
 
-  test("Validate data fail - fees as 0 on mainnet environment") { implicit res =>
-    implicit val (h, hs, sp) = res
-
-    val primaryToken = TokenInformation(CurrencyId(Address("DAG0DQPuvVThrHnz66S4V6cocrtpg59oesAWyRMb")).some, 100L)
-    val pairToken = TokenInformation(CurrencyId(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5")).some, 50L)
-    val ammOnChainState = AmmOnChainState(SortedSet.empty, None)
-    val ammCalculatedState = AmmCalculatedState()
-    val state = DataState(ammOnChainState, ammCalculatedState)
-    val ownerAddress = Address("DAG6t89ps7G8bfS2WuTcNUAy9Pg8xWqiEHjrrLAZ")
-
-    val liquidityPoolUpdate = LiquidityPoolUpdate(
-      CurrencyId(ownerAddress),
-      sourceAddress,
-      Hash.empty,
-      Hash.empty,
-      primaryToken.identifier,
-      pairToken.identifier,
-      primaryToken.amount,
-      pairToken.amount,
-      EpochProgress.MaxValue,
-      FeeDistributor.empty.some
-    )
-
-    val fakeSignedUpdate = getFakeSignedUpdate(liquidityPoolUpdate)
-
-    val liquidityPoolValidations = LiquidityPoolValidations.make[IO](config)
-    val stakingValidations = StakingValidations.make[IO](config)
-    val swapValidations = SwapValidations.make[IO](config)
-    val withdrawalValidations = WithdrawalValidations.make[IO](config)
-    val governanceValidations = GovernanceValidations.make[IO]
-    val rewardWithdrawValidations = RewardWithdrawValidations.make[IO]()
-
-    val validationService = ValidationService.make[IO](
-      config.copy(environment = Mainnet),
-      liquidityPoolValidations,
-      stakingValidations,
-      swapValidations,
-      withdrawalValidations,
-      governanceValidations,
-      rewardWithdrawValidations
-    )
-    for {
-      keyPair <- KeyPairGenerator.makeKeyPair[IO]
-      implicit0(context: L0NodeContext[IO]) = buildL0NodeContext(
-        keyPair,
-        SortedMap.empty,
-        EpochProgress.MinValue,
-        SnapshotOrdinal.MinValue,
-        SortedMap.empty,
-        EpochProgress.MinValue,
-        SnapshotOrdinal.MinValue,
-        ownerAddress
+      validationService = ValidationService.make[IO](
+        config,
+        liquidityPoolValidations,
+        stakingValidations,
+        swapValidations,
+        withdrawalValidations,
+        governanceValidations,
+        rewardWithdrawValidations
       )
-      response <- validationService.validateData(NonEmptyList.one(fakeSignedUpdate), state)
+      response <- validationService.validateUpdate(liquidityPoolUpdate)(context)
     } yield expect(response == Errors.FeePercentageTotalMustBeGreaterThanZero.invalidNec)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,11 +8,11 @@ object Dependencies {
     val organizeImports = "0.5.0"
   }
 
-    def tessellation(artifact: String): ModuleID = {
-      val version = V.tessellation
-      println(s"Using tessellation version: $version") // Debug logging
-      "io.constellationnetwork" %% s"tessellation-$artifact" % version
-    }
+  def tessellation(artifact: String): ModuleID = {
+    val version = V.tessellation
+    println(s"Using tessellation version: $version") // Debug logging
+    "io.constellationnetwork" %% s"tessellation-$artifact" % version
+  }
 
   def decline(artifact: String = ""): ModuleID =
     "com.monovore" %% {


### PR DESCRIPTION
### Changes
+ Moving the L0 validations to combine function to avoid silent rejections and to track the failures