### PR TITLE
chore: bump tessellation to 3.5.20

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
 
   object V {
-    val tessellation = "3.5.4"
+    val tessellation = "3.5.20"
     val decline = "2.4.1"
     val scalafixRules = "0.1.2"
   }


### PR DESCRIPTION
## Summary
Bumps the Tessellation SDK to **3.5.20**, which the team confirmed contains **all** prior fixes (including the `rollback-fix` the mainnet nodes currently run as the custom `3.5.12-rollback-fix.1` build).

## Validation (local, JDK 11)
- ✅ Resolves from githubPackages — **no amm-metagraph code changes needed** (API-compatible).
- ✅ `compile` + `Test/compile` clean.
- ✅ Full `sharedData` suite: **116 tests, 0 failures** (includes the determinism/AMM regression specs from #171).

## ⚠️ CI / release follow-up
`.github/workflows/main.yml` pins `tessellation_commit_hash` for the setup-environment Tessellation build. Align it to the **v3.5.20** commit (or confirm CI resolves 3.5.20 from githubPackages) so CI builds against the same artifact validated here.

## Deploy note (mainnet, real funds)
This is a consensus-framework change. Roll out to **all** mainnet nodes together, ideally **canary node 1 first** and watch snapshots before nodes 2 & 3. Combined with the activation epoch from #171 (486666, ~5h), ensure every node runs this build before that epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)