### PR TITLE
fix(D1-01): disable global-sync-data-integrity gate to stop mainnet restart loop

### DIFF
--- a/modules/shared_data/src/main/resources/application.conf
+++ b/modules/shared_data/src/main/resources/application.conf
@@ -87,7 +87,14 @@ activation-epochs {
     staking-share-mint-fix = 486666
     staking-share-mint-fix = ${?STAKING_SHARE_MINT_FIX_ACTIVATION_EPOCH}
     # D1-01: fail-closed on incomplete global-sync data (metagraph-epoch space).
-    global-sync-data-integrity = 486666
+    # DISABLED (EpochProgress.MaxValue). When active at 486666 this gate deadlocked every node on restart/rollback:
+    # the consensus combine demands the contiguous global-snapshot range (lastSync .. tip] from the node-local
+    # GlobalSnapshotsStorage, but that cache is in-memory and forward-only (filled only by onGlobalSnapshotPull going
+    # forward), so the historical part of the range after a restart is never present -> IllegalStateException every
+    # round -> lastSyncGlobalSnapshotOrdinal frozen -> monitor restart loop. The gate's own prerequisite ("deploy
+    # cache persistence first, let caches fill") was never shipped. Keep DISABLED until GlobalSnapshotsStorage
+    # backfills the (lastSync .. tip] gap on startup; only then re-coordinate a future activation epoch across all nodes.
+    global-sync-data-integrity = 9223372036854775807
     global-sync-data-integrity = ${?GLOBAL_SYNC_DATA_INTEGRITY_ACTIVATION_EPOCH}
     # D2-06: distribute rewards for every scheduled boundary crossed on an epoch jump (metagraph-epoch space).
     reward-epoch-catch-up = 486666

--- a/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/app/ApplicationConfigSpec.scala
+++ b/modules/shared_data/src/test/scala/org/amm_metagraph/shared_data/app/ApplicationConfigSpec.scala
@@ -18,7 +18,10 @@ object ApplicationConfigSpec extends SimpleIOSuite {
     val cfg = ApplicationConfigOps.readDefaultPure
     expect.all(
       cfg.activationEpochs.stakingShareMintFix == rolloutEpoch,
-      cfg.activationEpochs.globalSyncDataIntegrity == rolloutEpoch,
+      // D1-01 is DISABLED (EpochProgress.MaxValue) until GlobalSnapshotsStorage backfills the (lastSync .. tip] gap on
+      // startup; active at 486666 it deadlocked every node on restart/rollback. Re-coordinate a future epoch only
+      // after the backfill ships. Keep this assertion in lockstep with application.conf.
+      cfg.activationEpochs.globalSyncDataIntegrity == EpochProgress.MaxValue,
       cfg.activationEpochs.rewardEpochCatchUp == rolloutEpoch
     )
   }


### PR DESCRIPTION
## Incident: mainnet restart loop (P3, env:MainNet)

After the coordinated activation epoch **486666** turned on the D1-01 *"fail-closed on incomplete global-sync data"* gate, every Pacaswap mainnet node entered a restart loop. The monitor's *"Check If Global Snapshot Sync Is Progressing"* check kept restarting nodes because `lastSyncGlobalSnapshotOrdinal` stopped advancing.

### Root cause
`ContextHelper` runs the combine with `failOnMissing = currentSnapshotEpochProgress >= globalSyncDataIntegrity` (486666). When active, `getSpendActionsFromGlobalSnapshots` (`globalSnapshots.scala`) demands the **contiguous** range `(lastSync .. tip]` from the node-local `GlobalSnapshotsStorage` and raises `IllegalStateException` on any gap.

But `GlobalSnapshotsStorage` is **in-memory and forward-only** — its only writer is `onGlobalSnapshotPull` (`MetagraphL0Service.scala:162`), which fills it going forward as new global snapshots arrive. There is **no backfill**. After a restart/rollback (the monitor restarts this metagraph with `run-rollback`), the persisted `calculated.lastSyncGlobalSnapshotOrdinal` is far below the live tip, so the historical part of the range is never present:

```
IllegalStateException: Incomplete global-sync data: missing List(6492745, 6492746, … tip)
```

→ combine falls back to old state → `lastSyncGlobalSnapshotOrdinal` frozen → monitor restarts → loop, gap growing each cycle.

**Observed on mainnet during the incident:** leader `Ready` but frozen at global ordinal **6,492,744** while GL0 advanced to **6,495,110+**; the two followers stuck in `Observing`. The configured GL0 peer serves the "missing" ordinals (HTTP 200) — the data is simply never loaded into the forward-only cache.

The gate's own documented prerequisite (in `ApplicationConfig.scala`) — *"deploy cache persistence first, let caches fill, THEN set this to a future epoch"* — was never shipped.

### This change (mitigation)
- Set `global-sync-data-integrity` to `EpochProgress.MaxValue` (disabled) in `application.conf`, reverting to the pre-486666 behavior that was live and progressing. The fix belongs in the **jar** (not a per-node monitor env override) so external node operators get correct behavior by pulling the build.
- Left `staking-share-mint-fix` and `reward-epoch-catch-up` at 486666 — they do not fail-closed and are not implicated.
- Updated `ApplicationConfigSpec` to assert the new value.

### Rollout
Coordinated: **all nodes** must run this jar (a node still on the 486666 build keeps stalling/diverging). The env escape hatch `GLOBAL_SYNC_DATA_INTEGRITY_ACTIVATION_EPOCH` is preserved.

### Follow-up (separate PR)
Make `GlobalSnapshotsStorage` backfill the `(lastSync .. tip]` gap on startup (persist + reload), then re-coordinate a future activation epoch so D1-01 can be safely re-enabled.

### Validation
⚠️ Local `sbt` could not load the build (corrupted local sbt/Scala launcher — fails at project load under both JDK 11 and 21, independent of this change). Relying on **CI** to compile and run `ApplicationConfigSpec`. The change is a single HOCON value + matching test assertion; `EpochProgress.MaxValue` is already the in-code default at `ApplicationConfig.scala:128`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)